### PR TITLE
Create HttpCustomHeaderClient class can add HTTP headers an user want.

### DIFF
--- a/src/main/java/org/imsglobal/caliper/clients/HttpCustomHeader.java
+++ b/src/main/java/org/imsglobal/caliper/clients/HttpCustomHeader.java
@@ -1,0 +1,63 @@
+/**
+ * This file is part of IMS Caliper Analytics™ and is licensed to
+ * IMS Global Learning Consortium, Inc. (http://www.imsglobal.org)
+ * under one or more contributor license agreements.  See the NOTICE
+ * file distributed with this work for additional information.
+ *
+ * IMS Caliper is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * IMS Caliper is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.imsglobal.caliper.clients;
+
+public class HttpCustomHeader {
+    private final String field;
+    private String value;
+    private static final String[] PROHIBITED_HEADERS = new String[] { "content-type", "authorization" };
+
+    public HttpCustomHeader(String field, String value) {
+
+        for (String header: PROHIBITED_HEADERS) {
+            if (header.equals(field.toLowerCase())) {
+                throw new IllegalArgumentException("Setting " + field + " header not allowed.");
+            }
+        }
+
+        // Always save header fields in lower case because fields are case-insensitive.
+        // (From RFC 7230 Section 3.2 "Header Fields")
+        this.field = field.toLowerCase();
+        setValue(value);
+    }
+
+    public String getField() {
+        return this.field;
+    }
+
+    public String getValue() {
+        return this.value;
+    }
+
+    public void setValue(String value) {
+
+        if (value == null || value.length() == 0) {
+            throw new IllegalArgumentException("Empty header value not allowed.");
+        }
+
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return "HttpCustomHeader{" + "field='" + field + '\'' +
+                ", value='" + value + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/org/imsglobal/caliper/clients/HttpCustomHeaderClient.java
+++ b/src/main/java/org/imsglobal/caliper/clients/HttpCustomHeaderClient.java
@@ -1,0 +1,170 @@
+/**
+ * This file is part of IMS Caliper Analytics™ and is licensed to
+ * IMS Global Learning Consortium, Inc. (http://www.imsglobal.org)
+ * under one or more contributor license agreements.  See the NOTICE
+ * file distributed with this work for additional information.
+ *
+ * IMS Caliper is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * IMS Caliper is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.imsglobal.caliper.clients;
+
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.imsglobal.caliper.Envelope;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.HashMap;
+
+public class HttpCustomHeaderClient extends AbstractClient {
+    private static CloseableHttpClient httpClient;
+    private static CloseableHttpResponse response = null;
+    private static HashMap<String, String> customHeaders = null;
+
+    private static final Logger log = LoggerFactory.getLogger(HttpClient.class);
+
+    /**
+     * Constructor. The args options provides the host details to the HttpCustomHeaderClient.
+     * Scope is private to force use of the static factory method for instantiating an HttpCustomHeaderClient.
+     */
+    private HttpCustomHeaderClient(String id, HttpClientOptions options) {
+        super(id, options);
+        initialize();
+
+        if (customHeaders == null) {
+            customHeaders = new HashMap<>(0);
+        }
+    }
+
+    /**
+     * Init method
+     */
+    public static synchronized void initialize() {
+        if (httpClient == null) {
+            httpClient = HttpClients.createDefault();
+        }
+    }
+
+    /**
+     * Check initialized instance.
+     */
+    private static void checkInitialized() {
+        if (httpClient == null) {
+            throw new IllegalStateException("HttpClient is not initialized.");
+        }
+    }
+
+    /**
+     * Set custom header. (Except 'Content-Type' and 'Authorization')
+     * @param field: HTTP Header field
+     * @param value: HTTP Header value for the name
+     */
+    public void setCustomHeader(String field, String value) {
+
+        /* Because HTTP header fields are case-insensitive. (From RFC 7230 Section 3.2 "Header Fields") */
+        String lowerCaseField = field.toLowerCase();
+
+        if (lowerCaseField.equals("content-type") || lowerCaseField.equals("authorization")) {
+            return;
+        }
+
+        customHeaders.put(field, value);
+    }
+
+    /**
+     * Get custom header and add to HTTP header
+     * @param post: HttpPost object to send Envelope
+     */
+    private void getCustomHeader(HttpPost post) {
+        for (String name : customHeaders.keySet()) {
+            post.setHeader(name, customHeaders.get(name));
+        }
+    }
+
+    /**
+     * Post envelope.
+     * @param envelope
+     */
+    @Override
+    public void send(Envelope envelope) {
+        boolean status = Boolean.FALSE;
+
+        try {
+            if (log.isDebugEnabled()) {
+                log.debug("Entering send()...");
+            }
+
+            // Check if HttpClient is initialized.
+            checkInitialized();
+
+            // Serialize the envelope
+            String json = this.serializeEnvelope(envelope);
+
+            // Prep the post
+            HttpPost post = new HttpPost(super.getOptions().getHost());
+            post.setHeader("Authorization", this.getOptions().getApiKey());
+            post.setHeader("Content-Type", this.getOptions().getContentType());
+            post.setEntity(new StringEntity(json, ContentType.APPLICATION_JSON));
+
+            // Get custom header and set header to HttpPost object
+            getCustomHeader(post);
+
+            // Execute POST
+            response = httpClient.execute(post);
+
+            // HTTP Response code
+            int statusCode = response.getStatusLine().getStatusCode();
+            if (statusCode < 200 || statusCode > 202) {
+                response.close();
+
+                // Update statistics
+                updateStatistics(Boolean.TRUE);
+
+                throw new RuntimeException("WARN: HTTP POST failed; status code=" + statusCode);
+            } else {
+                if (log.isDebugEnabled()) {
+                    log.debug(response.getStatusLine().toString());
+                    log.debug(EntityUtils.toString(response.getEntity()));
+                }
+                response.close();
+
+                // Update statistics
+                updateStatistics(Boolean.FALSE);
+
+                if (log.isDebugEnabled()) {
+                    log.debug("Exiting send()...");
+                }
+            }
+        } catch (ClientProtocolException cpe) {
+            cpe.printStackTrace();
+        } catch (IOException ioe) {
+            ioe.printStackTrace();
+        }
+    }
+
+    /**
+     * Factory method for instantiating an HttpCustomHeaderClient.
+     * @param id
+     * @return HttpCustomHeaderClient
+     */
+    public static HttpCustomHeaderClient create(String id, HttpClientOptions options) {
+        return new HttpCustomHeaderClient(id, options);
+    }
+}

--- a/src/test/java/org/imsglobal/caliper/SensorSendCustomHeaderEventsTest.java
+++ b/src/test/java/org/imsglobal/caliper/SensorSendCustomHeaderEventsTest.java
@@ -1,0 +1,119 @@
+package org.imsglobal.caliper;
+
+import org.imsglobal.caliper.actions.Action;
+import org.imsglobal.caliper.clients.HttpCustomHeaderClient;
+import org.imsglobal.caliper.clients.HttpClientOptions;
+import org.imsglobal.caliper.config.Config;
+import org.imsglobal.caliper.context.JsonldStringContext;
+import org.imsglobal.caliper.entities.agent.*;
+import org.imsglobal.caliper.entities.resource.WebPage;
+import org.imsglobal.caliper.entities.session.Session;
+import org.imsglobal.caliper.events.NavigationEvent;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+
+public class SensorSendCustomHeaderEventsTest {
+    private static final String BASE_IRI = "https://example.edu";
+    private static final String ENDPOINT = "https://example.edu/endpoint";
+
+    // private static final Logger log = LoggerFactory.getLogger(SensorSendEventsTest.class);
+
+    @Test
+    public void test() {
+
+        // Initialize Sensor, Client and Requester provisioned with Options
+        Sensor sensor = Sensor.create(BASE_IRI.concat("/sensors/1"));
+        HttpClientOptions opts = HttpClientOptions.builder()
+                                    .host(ENDPOINT)
+                                    .apiKey("Bearer 2e8317a0-86ed-4674-a0ea-b211233c94cf")
+                                    .build();
+        HttpCustomHeaderClient client = HttpCustomHeaderClient.create(sensor.getId(), opts);
+        sensor.registerClient(client);
+
+        // Fire event test - Send a envelope containing the above event
+        JsonldStringContext context = JsonldStringContext.getDefault();
+
+        String id = "urn:id:" + UUID.randomUUID().toString();
+
+        Person actor = Person.builder().id(BASE_IRI.concat("/users/554433")).build();
+
+        String currentLocation = BASE_IRI.concat("/terms/201601/courses/7/sections/1/pages/1");
+        String previousLocation = BASE_IRI.concat("/terms/201601/courses/7/sections/1/pages/1");
+
+        WebPage object = WebPage.builder()
+                .id(currentLocation)
+                .name("Learning Analytics Specifications")
+                .description("Overview of Learning Analytics Specifications with particular emphasis on IMS Caliper.")
+                .dateCreated(new DateTime(2016, 8, 1, 9, 0, 0, 0, DateTimeZone.UTC))
+                .build();
+
+        WebPage referrer = WebPage.builder().id(previousLocation).build();
+
+        SoftwareApplication edApp = SoftwareApplication.builder().id(BASE_IRI).build();
+
+        CourseSection group = CourseSection.builder().id(BASE_IRI.concat("/terms/201601/courses/7/sections/1"))
+                .courseNumber("CPS 435-01")
+                .academicSession("Fall 2016")
+                .build();
+
+        Membership membership = Membership.builder()
+                .id(BASE_IRI.concat("/terms/201601/courses/7/sections/1/rosters/1"))
+                .member(actor)
+                .organization(CourseSection.builder().id(group.getId()).build())
+                .status(Status.ACTIVE)
+                .role(Role.LEARNER)
+                .dateCreated(new DateTime(2016, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
+                .build();
+
+        Session session = Session.builder()
+                .id(BASE_IRI.concat("/sessions/1f6442a482de72ea6ad134943812bff564a76259"))
+                .startedAtTime(new DateTime(2016, 11, 15, 10, 0, 0, 0, DateTimeZone.UTC))
+                .build();
+
+        NavigationEvent event = NavigationEvent.builder()
+                .context(context)
+                .id(id)
+                .actor(actor)
+                .action(Action.NAVIGATED_TO)
+                .object(object)
+                .eventTime(new DateTime(DateTimeZone.UTC))
+                .referrer(referrer)
+                .edApp(edApp)
+                .group(group)
+                .membership(membership)
+                .session(session)
+                .build();
+
+        // Prep envelope
+        DateTime sendTime = new DateTime(DateTimeZone.UTC);
+        List<Object> data = new ArrayList<>();
+        data.add(event);
+
+        // Add additional headers
+        client.setCustomHeader("Accept", "*/*");
+
+        // These header will not be added
+        client.setCustomHeader("Content-Type", "text");
+        client.setCustomHeader("content-type", "text");
+        client.setCustomHeader("Authorization", "Basic 1234");
+        client.setCustomHeader("AUTHORIZATION", "Bearer 123121421421414");
+
+        Envelope envelope = sensor.create(client.getId(), sendTime, Config.DATA_VERSION, data);
+
+        // Send envelope
+        sensor.send(client, envelope);
+
+        // TODO: These assertion throws NullPointerException.
+        /*
+        assertEquals("Expect fifty Caliper events to be sent", 1,
+                sensor.getStatistics().get("default").getMeasures().getCount());
+        */
+    }
+}

--- a/src/test/java/org/imsglobal/caliper/SensorSendCustomHeaderEventsTest.java
+++ b/src/test/java/org/imsglobal/caliper/SensorSendCustomHeaderEventsTest.java
@@ -1,6 +1,25 @@
+/**
+ * This file is part of IMS Caliper Analytics™ and is licensed to
+ * IMS Global Learning Consortium, Inc. (http://www.imsglobal.org)
+ * under one or more contributor license agreements.  See the NOTICE
+ * file distributed with this work for additional information.
+ *
+ * IMS Caliper is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * IMS Caliper is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package org.imsglobal.caliper;
 
 import org.imsglobal.caliper.actions.Action;
+import org.imsglobal.caliper.clients.HttpCustomHeader;
 import org.imsglobal.caliper.clients.HttpCustomHeaderClient;
 import org.imsglobal.caliper.clients.HttpClientOptions;
 import org.imsglobal.caliper.config.Config;
@@ -11,6 +30,8 @@ import org.imsglobal.caliper.entities.session.Session;
 import org.imsglobal.caliper.events.NavigationEvent;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -18,28 +39,31 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 public class SensorSendCustomHeaderEventsTest {
     private static final String BASE_IRI = "https://example.edu";
-    private static final String ENDPOINT = "https://example.edu/endpoint";
+    private static final String ENDPOINT = "https://caliper.imsglobal.org/caliper/f6c96fef-c3bd-4348-8fad-d41300f350f9/message";
 
-    // private static final Logger log = LoggerFactory.getLogger(SensorSendEventsTest.class);
+    // Initialize Sensor, Client and Requester provisioned with Options
+    private static Sensor sensor = Sensor.create(BASE_IRI.concat("/sensors/1"));
+    private static HttpClientOptions opts = HttpClientOptions.builder()
+                                                .host(ENDPOINT)
+                                                .apiKey("Bearer f6c96fef-c3bd-4348-8fad-d41300f350f9")
+                                                .build();
+    private static HttpCustomHeaderClient client = HttpCustomHeaderClient.create(sensor.getId(), opts);
+    private static JsonldStringContext context = JsonldStringContext.getDefault();
 
-    @Test
-    public void test() {
+    // Caliper event
+    private NavigationEvent event;
 
-        // Initialize Sensor, Client and Requester provisioned with Options
-        Sensor sensor = Sensor.create(BASE_IRI.concat("/sensors/1"));
-        HttpClientOptions opts = HttpClientOptions.builder()
-                                    .host(ENDPOINT)
-                                    .apiKey("Bearer 2e8317a0-86ed-4674-a0ea-b211233c94cf")
-                                    .build();
-        HttpCustomHeaderClient client = HttpCustomHeaderClient.create(sensor.getId(), opts);
+    @BeforeClass
+    public static void initializeSensorWithClient() {
         sensor.registerClient(client);
+    }
 
-        // Fire event test - Send a envelope containing the above event
-        JsonldStringContext context = JsonldStringContext.getDefault();
-
+    @Before
+    public void setUpCaliperEntityAndEvent() {
         String id = "urn:id:" + UUID.randomUUID().toString();
 
         Person actor = Person.builder().id(BASE_IRI.concat("/users/554433")).build();
@@ -77,7 +101,7 @@ public class SensorSendCustomHeaderEventsTest {
                 .startedAtTime(new DateTime(2016, 11, 15, 10, 0, 0, 0, DateTimeZone.UTC))
                 .build();
 
-        NavigationEvent event = NavigationEvent.builder()
+        event = NavigationEvent.builder()
                 .context(context)
                 .id(id)
                 .actor(actor)
@@ -90,6 +114,10 @@ public class SensorSendCustomHeaderEventsTest {
                 .membership(membership)
                 .session(session)
                 .build();
+    }
+
+    @Test
+    public void testSendSingleEvent() {
 
         // Prep envelope
         DateTime sendTime = new DateTime(DateTimeZone.UTC);
@@ -99,21 +127,165 @@ public class SensorSendCustomHeaderEventsTest {
         // Add additional headers
         client.setCustomHeader("Accept", "*/*");
 
-        // These header will not be added
-        client.setCustomHeader("Content-Type", "text");
-        client.setCustomHeader("content-type", "text");
-        client.setCustomHeader("Authorization", "Basic 1234");
-        client.setCustomHeader("AUTHORIZATION", "Bearer 123121421421414");
-
         Envelope envelope = sensor.create(client.getId(), sendTime, Config.DATA_VERSION, data);
 
         // Send envelope
         sensor.send(client, envelope);
 
-        // TODO: These assertion throws NullPointerException.
-        /*
-        assertEquals("Expect fifty Caliper events to be sent", 1,
-                sensor.getStatistics().get("default").getMeasures().getCount());
-        */
+        assertEquals("Expect a Caliper event with custom header to be sent",
+                client.getStatistics().getMeasures().getCount(),
+                client.getStatistics().getSuccessful().getCount());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSetContentTypeHeader() {
+
+        // Prep envelope
+        DateTime sendTime = new DateTime(DateTimeZone.UTC);
+        List<Object> data = new ArrayList<>();
+        data.add(event);
+
+        // Add additional headers
+        client.setCustomHeader("Content-Type", "text");
+
+        Envelope envelope = sensor.create(client.getId(), sendTime, Config.DATA_VERSION, data);
+        sensor.send(client, envelope);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSetAuthorizationHeader() {
+
+        // Prep envelope
+        DateTime sendTime = new DateTime(DateTimeZone.UTC);
+        List<Object> data = new ArrayList<>();
+        data.add(event);
+
+        // Add additional headers
+        client.setCustomHeader("Authorization", "Bearer 123121421421414");
+
+        Envelope envelope = sensor.create(client.getId(), sendTime, Config.DATA_VERSION, data);
+        sensor.send(client, envelope);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSetHeaderBlankString() {
+        // Prep envelope
+        DateTime sendTime = new DateTime(DateTimeZone.UTC);
+        List<Object> data = new ArrayList<>();
+        data.add(event);
+
+        // Add additional headers
+        client.setCustomHeader("Accept", "");
+
+        Envelope envelope = sensor.create(client.getId(), sendTime, Config.DATA_VERSION, data);
+        sensor.send(client, envelope);
+    }
+
+    @Test
+    public void testSetCustomHeaderList() {
+        // Prep envelope
+        DateTime sendTime = new DateTime(DateTimeZone.UTC);
+        List<Object> data = new ArrayList<>();
+        data.add(event);
+
+        List<HttpCustomHeader> headerList = new ArrayList<HttpCustomHeader>() {{
+            add(new HttpCustomHeader("accept", "*/*"));
+            add(new HttpCustomHeader("user-agent", "Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:59.0) Gecko/20100101 Firefox/59.0"));
+        }};
+
+        client.setCustomHeaders(headerList);
+
+        assertEquals("Check size of custom header list",
+                client.getCustomHeaders().size(),
+                2);
+        assertNotEquals("Check 'accept' header exists in custom header list",
+                client.findCustomHeader("accept"),
+                -1);
+        assertNotEquals("Check 'user-agent' header exists in custom header list",
+                client.findCustomHeader("user-agent"),
+                -1);
+
+        Envelope envelope = sensor.create(client.getId(), sendTime, Config.DATA_VERSION, data);
+        sensor.send(client, envelope);
+
+        assertEquals("Expect a Caliper event with custom headers to be sent",
+                client.getStatistics().getMeasures().getCount(),
+                client.getStatistics().getSuccessful().getCount());
+    }
+
+    @Test
+    public void testRemoveCustomHeaderFromList() {
+        // Prep envelope
+        DateTime sendTime = new DateTime(DateTimeZone.UTC);
+        List<Object> data = new ArrayList<>();
+        data.add(event);
+
+        List<HttpCustomHeader> headerList = new ArrayList<HttpCustomHeader>() {{
+            add(new HttpCustomHeader("accept", "*/*"));
+            add(new HttpCustomHeader("user-agent", "Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:59.0) Gecko/20100101 Firefox/59.0"));
+        }};
+
+        client.setCustomHeaders(headerList);
+
+        client.removeCustomHeader("user-agent");
+
+        assertEquals("Check size of custom header list",
+                client.getCustomHeaders().size(),
+                1);
+        assertEquals("Check 'user-agent' header deleted from custom header list",
+                client.findCustomHeader("user-agent"),
+                -1);
+
+        Envelope envelope = sensor.create(client.getId(), sendTime, Config.DATA_VERSION, data);
+        sensor.send(client, envelope);
+
+        assertEquals("Expect a Caliper event without 'user-agent' header to be sent",
+                client.getStatistics().getMeasures().getCount(),
+                client.getStatistics().getSuccessful().getCount());
+    }
+
+    @Test
+    public void testClearAllCustomHeaders() {
+        // Prep envelope
+        DateTime sendTime = new DateTime(DateTimeZone.UTC);
+        List<Object> data = new ArrayList<>();
+        data.add(event);
+
+        List<HttpCustomHeader> headerList = new ArrayList<HttpCustomHeader>() {{
+            add(new HttpCustomHeader("accept", "*/*"));
+            add(new HttpCustomHeader("user-agent", "Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:59.0) Gecko/20100101 Firefox/59.0"));
+        }};
+
+        client.setCustomHeaders(headerList);
+        client.removeAllCustomHeaders();
+
+        assertEquals("Check size of custom header list",
+                client.getCustomHeaders().size(),
+                0);
+
+        Envelope envelope = sensor.create(client.getId(), sendTime, Config.DATA_VERSION, data);
+        //sensor.send(client, envelope);
+    }
+
+    @Test
+    public void testUpdateCustomHeader() {
+        // Prep envelope
+        DateTime sendTime = new DateTime(DateTimeZone.UTC);
+        List<Object> data = new ArrayList<>();
+        data.add(event);
+
+        // Add additional headers
+        client.setCustomHeader("Accept", "*/*");
+        assertEquals("", client.getCustomHeaders().get(0).getValue(), "*/*");
+
+        client.setCustomHeader("Accept", "application/json");
+        assertEquals("", client.getCustomHeaders().get(0).getValue(), "application/json");
+
+        Envelope envelope = sensor.create(client.getId(), sendTime, Config.DATA_VERSION, data);
+        sensor.send(client, envelope);
+
+        assertEquals("Expect a Caliper event with updated custom headers to be sent",
+                client.getStatistics().getMeasures().getCount(),
+                client.getStatistics().getSuccessful().getCount());
     }
 }


### PR DESCRIPTION
(Refer #341)

* I can't extend HttpClient because attributes of `HttpClient` is in private scope. So I created the new class named `HttpCustomHeaderClient`.
* It works same as HttpClient, but the only difference is that you can add HTTP headers you want.
* You can add HTTP headers you want. And you can see these codes below in SensorSendCustomHeaderEventsTest class

```
        HttpCustomHeaderClient client = HttpCustomHeaderClient.create(sensor.getId(), opts);

        // Add additional headers
        client.setCustomHeader("Accept", "*/*");

        // These header will not be added
        client.setCustomHeader("Content-Type", "text");
        client.setCustomHeader("content-type", "text");
        client.setCustomHeader("Authorization", "Basic 1234");
        client.setCustomHeader("AUTHORIZATION", "Bearer 123121421421414");
```

* If you try to add "Content-Type" and "Authorization" headers, it will be ignored.
* I think it is not a good solution. But I think it can help a developer who needs some test using additional HTTP header.

I'll wait for your review. Thank you.

