### PR TITLE
Concrete Event/Entity classes should extend from appropriate abstract class

### DIFF
--- a/src/main/java/org/imsglobal/caliper/entities/Collection.java
+++ b/src/main/java/org/imsglobal/caliper/entities/Collection.java
@@ -28,7 +28,7 @@ import java.util.List;
 /**
  * Concrete implementation of a generic Collection.
  */
-public class Collection extends Entity implements CaliperCollection<CaliperEntity> {
+public class Collection extends AbstractEntity implements CaliperCollection<CaliperEntity> {
 
     @JsonProperty("items")
     private final ImmutableList<CaliperEntity> items;
@@ -54,7 +54,7 @@ public class Collection extends Entity implements CaliperCollection<CaliperEntit
      * Builder class provides a fluid interface for setting object properties.
      * @param <T> builder.
      */
-    public static abstract class Builder<T extends Builder<T>> extends Entity.Builder<T> {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractEntity.Builder<T> {
         private List<CaliperEntity> items = Lists.newArrayList();
 
         /**

--- a/src/main/java/org/imsglobal/caliper/entities/agent/Agent.java
+++ b/src/main/java/org/imsglobal/caliper/entities/agent/Agent.java
@@ -18,10 +18,10 @@
 
 package org.imsglobal.caliper.entities.agent;
 
-import org.imsglobal.caliper.entities.Entity;
+import org.imsglobal.caliper.entities.AbstractEntity;
 import org.imsglobal.caliper.entities.EntityType;
 
-public class Agent extends Entity implements CaliperAgent {
+public class Agent extends AbstractEntity implements CaliperAgent {
 
     /**
      * @param builder apply builder object properties to the object.
@@ -34,7 +34,7 @@ public class Agent extends Entity implements CaliperAgent {
      * Builder class provides a fluid interface for setting object properties.
      * @param <T> builder.
      */
-    public static abstract class Builder<T extends Builder<T>> extends Entity.Builder<T> {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractEntity.Builder<T> {
 
         /**
          * Constructor

--- a/src/main/java/org/imsglobal/caliper/entities/agent/CourseSection.java
+++ b/src/main/java/org/imsglobal/caliper/entities/agent/CourseSection.java
@@ -33,7 +33,7 @@ import javax.annotation.Nullable;
  * A Caliper CourseSection provides a subset of the CourseSection properties specified in the
  * IMS LTI 2.0 specification, which in turn, draws inspiration from the IMS LIS 1.0 specification.
  */
-public class CourseSection extends CourseOffering {
+public class CourseSection extends AbstractCourse {
 
     @JsonProperty("category")
     private final String category;
@@ -58,7 +58,7 @@ public class CourseSection extends CourseOffering {
      * Builder class provides a fluid interface for setting object properties.
      * @param <T> builder.
      */
-    public static abstract class Builder<T extends Builder<T>> extends CourseOffering.Builder<T> {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractCourse.Builder<T> {
         private String category;
 
         /**

--- a/src/main/java/org/imsglobal/caliper/entities/agent/Group.java
+++ b/src/main/java/org/imsglobal/caliper/entities/agent/Group.java
@@ -23,7 +23,7 @@ import org.imsglobal.caliper.entities.EntityType;
 /**
  * A Caliper Group represents an ad-hoc organization that an Agent, typically a Person or another Group is able to join as a member.
  */
-public class Group extends Organization {
+public class Group extends AbstractOrganization {
 
     /**
      * @param builder apply builder object properties to the object.
@@ -36,7 +36,7 @@ public class Group extends Organization {
      * Builder class provides a fluid interface for setting object properties.
      * @param <T> builder.
      */
-    public static abstract class Builder<T extends Builder<T>> extends Organization.Builder<T> {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractOrganization.Builder<T> {
 
         /**
          * Constructor

--- a/src/main/java/org/imsglobal/caliper/entities/agent/Membership.java
+++ b/src/main/java/org/imsglobal/caliper/entities/agent/Membership.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import org.imsglobal.caliper.entities.AbstractEntity;
-import org.imsglobal.caliper.entities.Entity;
 import org.imsglobal.caliper.entities.EntityType;
 
 import javax.annotation.Nonnull;
@@ -35,7 +34,7 @@ import java.util.List;
  * and Group, all of which implement the Joinable marker interface. Only a Membership object can be a memberId.
  */
 @SupportedStatuses({Status.ACTIVE, Status.INACTIVE})
-public class Membership extends Entity {
+public class Membership extends AbstractEntity {
 
     @JsonProperty("member")
     private final CaliperAgent member;
@@ -97,7 +96,7 @@ public class Membership extends Entity {
      * Builder class provides a fluid interface for setting object properties.
      * @param <T> builder.
      */
-    public static abstract class Builder<T extends Builder<T>> extends Entity.Builder<T> {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractEntity.Builder<T> {
         private CaliperAgent member;
         private CaliperOrganization organization;
         private List<Role> roles = Lists.newArrayList();

--- a/src/main/java/org/imsglobal/caliper/entities/agent/Person.java
+++ b/src/main/java/org/imsglobal/caliper/entities/agent/Person.java
@@ -21,7 +21,7 @@ package org.imsglobal.caliper.entities.agent;
 import org.imsglobal.caliper.entities.AbstractEntity;
 import org.imsglobal.caliper.entities.EntityType;
 
-public class Person extends Agent {
+public class Person extends AbstractEntity implements CaliperAgent {
 
     /**
      * @param builder apply builder object properties to the object.
@@ -34,7 +34,7 @@ public class Person extends Agent {
      * Builder class provides a fluid interface for setting object properties.
      * @param <T> builder.
      */
-    public static abstract class Builder<T extends Builder<T>> extends Agent.Builder<T> {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractEntity.Builder<T> {
 
         /**
          * Constructor

--- a/src/main/java/org/imsglobal/caliper/entities/agent/SoftwareApplication.java
+++ b/src/main/java/org/imsglobal/caliper/entities/agent/SoftwareApplication.java
@@ -19,12 +19,13 @@
 package org.imsglobal.caliper.entities.agent;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.imsglobal.caliper.entities.AbstractEntity;
 import org.imsglobal.caliper.entities.EntityType;
 import org.imsglobal.caliper.entities.CaliperReferable;
 
 import javax.annotation.Nullable;
 
-public class SoftwareApplication extends Agent implements CaliperReferable {
+public class SoftwareApplication extends AbstractEntity implements CaliperAgent, CaliperReferable {
 
     @JsonProperty("version")
     private final String version;
@@ -49,7 +50,7 @@ public class SoftwareApplication extends Agent implements CaliperReferable {
      * Builder class provides a fluid interface for setting object properties.
      * @param <T> builder.
      */
-    public static abstract class Builder<T extends Builder<T>> extends Agent.Builder<T> {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractEntity.Builder<T> {
         private String version;
 
         /**

--- a/src/main/java/org/imsglobal/caliper/entities/annotation/BookmarkAnnotation.java
+++ b/src/main/java/org/imsglobal/caliper/entities/annotation/BookmarkAnnotation.java
@@ -23,7 +23,7 @@ import org.imsglobal.caliper.entities.EntityType;
 
 import javax.annotation.Nullable;
 
-public class BookmarkAnnotation extends Annotation {
+public class BookmarkAnnotation extends AbstractAnnotation {
 
     @JsonProperty("bookmarkNotes")
     private String bookmarkNotes;
@@ -48,7 +48,7 @@ public class BookmarkAnnotation extends Annotation {
      * Builder class provides a fluid interface for setting object properties.
      * @param <T> builder.
      */
-    public static abstract class Builder<T extends Builder<T>> extends Annotation.Builder<T> {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractAnnotation.Builder<T> {
         private String bookmarkNotes;
 
         /**

--- a/src/main/java/org/imsglobal/caliper/entities/annotation/HighlightAnnotation.java
+++ b/src/main/java/org/imsglobal/caliper/entities/annotation/HighlightAnnotation.java
@@ -24,7 +24,7 @@ import org.imsglobal.caliper.selectors.Selector;
 
 import javax.annotation.Nullable;
 
-public class HighlightAnnotation extends Annotation {
+public class HighlightAnnotation extends AbstractAnnotation {
 
     @JsonProperty("selection")
     private Selector selection;
@@ -53,7 +53,7 @@ public class HighlightAnnotation extends Annotation {
      * Builder class provides a fluid interface for setting object properties.
      * @param <T> builder.
      */
-    public static abstract class Builder<T extends Builder<T>> extends Annotation.Builder<T> {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractAnnotation.Builder<T> {
         private Selector selection;
         private String selectionText;
 

--- a/src/main/java/org/imsglobal/caliper/entities/annotation/SharedAnnotation.java
+++ b/src/main/java/org/imsglobal/caliper/entities/annotation/SharedAnnotation.java
@@ -27,7 +27,7 @@ import org.imsglobal.caliper.entities.agent.CaliperAgent;
 import javax.annotation.Nullable;
 import java.util.List;
 
-public class SharedAnnotation extends Annotation {
+public class SharedAnnotation extends AbstractAnnotation {
 
     @JsonProperty("withAgents")
     private final ImmutableList<CaliperAgent> withAgents;
@@ -53,7 +53,7 @@ public class SharedAnnotation extends Annotation {
      * Builder class provides a fluid interface for setting object properties.
      * @param <T> builder.
      */
-    public static abstract class Builder<T extends Builder<T>> extends Annotation.Builder<T> {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractAnnotation.Builder<T> {
         private List<CaliperAgent> withAgents = Lists.newArrayList();
 
         /**

--- a/src/main/java/org/imsglobal/caliper/entities/annotation/TagAnnotation.java
+++ b/src/main/java/org/imsglobal/caliper/entities/annotation/TagAnnotation.java
@@ -26,7 +26,7 @@ import org.imsglobal.caliper.entities.EntityType;
 import javax.annotation.Nullable;
 import java.util.List;
 
-public class TagAnnotation extends Annotation {
+public class TagAnnotation extends AbstractAnnotation {
 
     @JsonProperty("tags")
     private ImmutableList<String> tags;
@@ -52,7 +52,7 @@ public class TagAnnotation extends Annotation {
      * Builder class provides a fluid interface for setting object properties.
      * @param <T> builder.
      */
-    public static abstract class Builder<T extends Builder<T>> extends Annotation.Builder<T> {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractAnnotation.Builder<T> {
         private List<String> tags = Lists.newArrayList();
 
         /**

--- a/src/main/java/org/imsglobal/caliper/entities/outcome/Attempt.java
+++ b/src/main/java/org/imsglobal/caliper/entities/outcome/Attempt.java
@@ -21,7 +21,10 @@ package org.imsglobal.caliper.entities.outcome;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.imsglobal.caliper.entities.*;
+import org.imsglobal.caliper.entities.AbstractEntity;
+import org.imsglobal.caliper.entities.CaliperGeneratable;
+import org.imsglobal.caliper.entities.EntityType;
+import org.imsglobal.caliper.entities.TimePeriod;
 import org.imsglobal.caliper.entities.agent.CaliperAgent;
 import org.imsglobal.caliper.entities.resource.CaliperDigitalResource;
 import org.imsglobal.caliper.validators.EntityValidator;
@@ -33,7 +36,7 @@ import javax.annotation.Nullable;
  * Representation of an Attempt. Attempts are generated as part of or
  * are the object of an interaction represented by an AssignableEvent.
  */
-public class Attempt extends Entity implements CaliperGeneratable {
+public class Attempt extends AbstractEntity implements CaliperGeneratable {
 
     @JsonProperty("assignable")
     private final CaliperDigitalResource assignable;
@@ -129,7 +132,7 @@ public class Attempt extends Entity implements CaliperGeneratable {
      * Builder class provides a fluid interface for setting object properties.
      * @param <T> builder.
      */
-    public static abstract class Builder<T extends Builder<T>> extends Entity.Builder<T> {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractEntity.Builder<T> {
         private CaliperDigitalResource assignable;
         private CaliperAgent assignee;
         private Attempt isPartOf;

--- a/src/main/java/org/imsglobal/caliper/entities/outcome/Result.java
+++ b/src/main/java/org/imsglobal/caliper/entities/outcome/Result.java
@@ -20,14 +20,14 @@ package org.imsglobal.caliper.entities.outcome;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.imsglobal.caliper.entities.AbstractEntity;
 import org.imsglobal.caliper.entities.CaliperGeneratable;
-import org.imsglobal.caliper.entities.Entity;
 import org.imsglobal.caliper.entities.EntityType;
 import org.imsglobal.caliper.entities.agent.CaliperAgent;
 
 import javax.annotation.Nullable;
 
-public class Result extends Entity implements CaliperGeneratable {
+public class Result extends AbstractEntity implements CaliperGeneratable {
 
     @JsonProperty("attempt")
     private Attempt attempt;
@@ -105,7 +105,7 @@ public class Result extends Entity implements CaliperGeneratable {
      * Builder class provides a fluid interface for setting object properties.
      * @param <T> builder.
      */
-    public static abstract class Builder<T extends Builder<T>> extends Entity.Builder<T> {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractEntity.Builder<T> {
         private Attempt attempt;
         private double maxResultScore;
         private double resultScore;

--- a/src/main/java/org/imsglobal/caliper/entities/outcome/Score.java
+++ b/src/main/java/org/imsglobal/caliper/entities/outcome/Score.java
@@ -20,14 +20,14 @@ package org.imsglobal.caliper.entities.outcome;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.imsglobal.caliper.entities.AbstractEntity;
 import org.imsglobal.caliper.entities.CaliperGeneratable;
-import org.imsglobal.caliper.entities.Entity;
 import org.imsglobal.caliper.entities.EntityType;
 import org.imsglobal.caliper.entities.agent.CaliperAgent;
 
 import javax.annotation.Nullable;
 
-public class Score extends Entity implements CaliperGeneratable {
+public class Score extends AbstractEntity implements CaliperGeneratable {
 
     @JsonProperty("attempt")
     private Attempt attempt;
@@ -105,7 +105,7 @@ public class Score extends Entity implements CaliperGeneratable {
      * Builder class provides a fluid interface for setting object properties.
      * @param <T> builder.
      */
-    public static abstract class Builder<T extends Builder<T>> extends Entity.Builder<T> {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractEntity.Builder<T> {
         private Attempt attempt;
         private double maxScore;
         private double scoreGiven;

--- a/src/main/java/org/imsglobal/caliper/entities/resource/AbstractMediaObject.java
+++ b/src/main/java/org/imsglobal/caliper/entities/resource/AbstractMediaObject.java
@@ -18,36 +18,59 @@
 
 package org.imsglobal.caliper.entities.resource;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.imsglobal.caliper.entities.EntityType;
 
-public class Document extends AbstractDigitalResource {
+import javax.annotation.Nullable;
+import java.util.List;
+
+/**
+ * This class provides a skeletal implementation of the Resource interface
+ * in order to minimize the effort required to implement the interface.
+ */
+public abstract class AbstractMediaObject extends AbstractDigitalResource implements CaliperMediaObject {
+
+    @JsonProperty("duration")
+    private String duration;
 
     /**
      * @param builder apply builder object properties to the object.
      */
-    protected Document(Builder<?> builder) {
+    protected AbstractMediaObject(Builder<?> builder) {
         super(builder);
+
+        this.duration = builder.duration;
+    }
+
+    /**
+     * @return duration
+     */
+    @Nullable
+    public String getDuration() {
+        return duration;
     }
 
     /**
      * Builder class provides a fluid interface for setting object properties.
-     * @param <T> builder.
+     * @param <T> builder
      */
-    public static abstract class Builder<T extends Builder<T>> extends AbstractDigitalResource.Builder<T> {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractDigitalResource.Builder<T>  {
+        private String duration;
 
-        /**
+        /*
          * Constructor
          */
         public Builder() {
-            super.type(EntityType.DOCUMENT);
+            super.type(EntityType.MEDIA_OBJECT);
         }
 
         /**
-         * Client invokes build method in order to create an immutable object.
-         * @return a new instance of the Document.
+         * @param duration
+         * @return duration
          */
-        public Document build() {
-            return new Document(this);
+        public T duration(String duration) {
+            this.duration = duration;
+            return self();
         }
     }
 
@@ -59,13 +82,5 @@ public class Document extends AbstractDigitalResource {
         protected Builder2 self() {
             return this;
         }
-    }
-
-    /**
-     * Static factory method.
-     * @return a new instance of the builder.
-     */
-    public static Builder<?> builder() {
-        return new Builder2();
     }
 }

--- a/src/main/java/org/imsglobal/caliper/entities/resource/AssessmentItem.java
+++ b/src/main/java/org/imsglobal/caliper/entities/resource/AssessmentItem.java
@@ -26,7 +26,7 @@ import javax.annotation.Nullable;
 /**
  * Caliper representation of an Assessment Item.  Part of the Assessment Metric Profile.
  */
-public class AssessmentItem extends AssignableDigitalResource implements CaliperAssessable {
+public class AssessmentItem extends AbstractAssignableDigitalResource implements CaliperAssessable {
 
     @JsonProperty("isTimeDependent")
     private final Boolean isTimeDependent;
@@ -59,7 +59,7 @@ public class AssessmentItem extends AssignableDigitalResource implements Caliper
      * Builder class provides a fluid interface for setting object properties.
      * @param <T> builder
      */
-    public static abstract class Builder<T extends Builder<T>> extends AssignableDigitalResource.Builder<T>  {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractAssignableDigitalResource.Builder<T>  {
         private Boolean isTimeDependent;
 
         /**

--- a/src/main/java/org/imsglobal/caliper/entities/resource/AudioObject.java
+++ b/src/main/java/org/imsglobal/caliper/entities/resource/AudioObject.java
@@ -26,7 +26,7 @@ import javax.annotation.Nullable;
 /**
  * An audio object embedded in a web page.
  */
-public class AudioObject extends MediaObject {
+public class AudioObject extends AbstractMediaObject implements CaliperMediaObject {
 
     @JsonProperty("volumeMin")
     private String volumeMin;
@@ -89,7 +89,7 @@ public class AudioObject extends MediaObject {
      * Builder class provides a fluid interface for setting object properties.
      * @param <T> builder
      */
-    public static abstract class Builder<T extends Builder<T>> extends MediaObject.Builder<T>  {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractMediaObject.Builder<T>  {
         private String volumeMin;
         private String volumeMax;
         private String volumeLevel;
@@ -134,7 +134,7 @@ public class AudioObject extends MediaObject {
          * @return builder
          */
         public T muted (boolean muted) {
-            this.muted = new Boolean(muted);
+            this.muted = muted;
             return self();
         }
 

--- a/src/main/java/org/imsglobal/caliper/entities/resource/Chapter.java
+++ b/src/main/java/org/imsglobal/caliper/entities/resource/Chapter.java
@@ -20,7 +20,7 @@ package org.imsglobal.caliper.entities.resource;
 
 import org.imsglobal.caliper.entities.EntityType;
 
-public class Chapter extends DigitalResource {
+public class Chapter extends AbstractDigitalResource {
 
     /**
      * @param builder apply builder object properties to the object.
@@ -33,7 +33,7 @@ public class Chapter extends DigitalResource {
      * Builder class provides a fluid interface for setting object properties.
      * @param <T> builder.
      */
-    public static abstract class Builder<T extends Builder<T>> extends DigitalResource.Builder<T> {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractDigitalResource.Builder<T> {
 
         /**
          * Constructor

--- a/src/main/java/org/imsglobal/caliper/entities/resource/DigitalResourceCollection.java
+++ b/src/main/java/org/imsglobal/caliper/entities/resource/DigitalResourceCollection.java
@@ -27,7 +27,7 @@ import org.imsglobal.caliper.entities.EntityType;
 import javax.annotation.Nullable;
 import java.util.List;
 
-public class DigitalResourceCollection extends DigitalResource implements CaliperCollection<CaliperDigitalResource> {
+public class DigitalResourceCollection extends AbstractDigitalResource implements CaliperCollection<CaliperDigitalResource> {
 
     @JsonProperty("items")
     private final ImmutableList<CaliperDigitalResource> items;
@@ -55,7 +55,7 @@ public class DigitalResourceCollection extends DigitalResource implements Calipe
      * Builder class provides a fluid interface for setting object properties.
      * @param <T> builder.
      */
-    public static abstract class Builder<T extends Builder<T>> extends DigitalResource.Builder<T> {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractDigitalResource.Builder<T> {
         private List<CaliperDigitalResource> items = Lists.newArrayList();
 
         /**

--- a/src/main/java/org/imsglobal/caliper/entities/resource/Forum.java
+++ b/src/main/java/org/imsglobal/caliper/entities/resource/Forum.java
@@ -27,7 +27,7 @@ import org.imsglobal.caliper.entities.EntityType;
 import javax.annotation.Nullable;
 import java.util.List;
 
-public class Forum extends DigitalResource implements CaliperCollection<Thread> {
+public class Forum extends AbstractDigitalResource implements CaliperCollection<Thread> {
 
     @JsonProperty("items")
     private final ImmutableList<Thread> items;
@@ -55,7 +55,7 @@ public class Forum extends DigitalResource implements CaliperCollection<Thread> 
      * Builder class provides a fluid interface for setting object properties.
      * @param <T> builder.
      */
-    public static abstract class Builder<T extends Builder<T>> extends DigitalResource.Builder<T> {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractDigitalResource.Builder<T> {
         private List<Thread> items = Lists.newArrayList();
 
         /**

--- a/src/main/java/org/imsglobal/caliper/entities/resource/Frame.java
+++ b/src/main/java/org/imsglobal/caliper/entities/resource/Frame.java
@@ -21,7 +21,7 @@ package org.imsglobal.caliper.entities.resource;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.imsglobal.caliper.entities.EntityType;
 
-public class Frame extends DigitalResource {
+public class Frame extends AbstractDigitalResource {
 
     @JsonProperty("index")
     private int index;
@@ -39,7 +39,7 @@ public class Frame extends DigitalResource {
      * Builder class provides a fluid interface for setting object properties.
      * @param <T> builder.
      */
-    public static abstract class Builder<T extends Builder<T>> extends DigitalResource.Builder<T> {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractDigitalResource.Builder<T> {
         private int index;
 
         /**

--- a/src/main/java/org/imsglobal/caliper/entities/resource/ImageObject.java
+++ b/src/main/java/org/imsglobal/caliper/entities/resource/ImageObject.java
@@ -25,7 +25,7 @@ import javax.annotation.Nullable;
 /**
  * An image object embedded in a web page.
  */
-public class ImageObject extends MediaObject {
+public class ImageObject extends AbstractMediaObject implements CaliperMediaObject {
 
     /**
      * @param builder apply builder object properties to the ImageObject object.
@@ -38,7 +38,7 @@ public class ImageObject extends MediaObject {
      * Builder class provides a fluid interface for setting object properties.
      * @param <T> builder
      */
-    public static abstract class Builder<T extends Builder<T>> extends MediaObject.Builder<T>  {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractMediaObject.Builder<T>  {
 
         /**
          * Initialize type with default value.  Required if builder().type() is not set by user.

--- a/src/main/java/org/imsglobal/caliper/entities/resource/LearningObjective.java
+++ b/src/main/java/org/imsglobal/caliper/entities/resource/LearningObjective.java
@@ -22,7 +22,7 @@ import org.imsglobal.caliper.entities.AbstractEntity;
 import org.imsglobal.caliper.entities.Entity;
 import org.imsglobal.caliper.entities.EntityType;
 
-public class LearningObjective extends Entity {
+public class LearningObjective extends AbstractEntity {
 
     /**
      * @param builder apply builder object properties to the object.
@@ -35,7 +35,7 @@ public class LearningObjective extends Entity {
      * Builder class provides a fluid interface for setting object properties.
      * @param <T> builder.
      */
-    public static abstract class Builder<T extends Builder<T>> extends Entity.Builder<T> {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractEntity.Builder<T> {
 
         /**
          * Constructor

--- a/src/main/java/org/imsglobal/caliper/entities/resource/MediaLocation.java
+++ b/src/main/java/org/imsglobal/caliper/entities/resource/MediaLocation.java
@@ -25,7 +25,7 @@ import org.imsglobal.caliper.entities.CaliperTargetable;
 /**
  * Media Location
  */
-public class MediaLocation extends DigitalResource implements CaliperTargetable {
+public class MediaLocation extends AbstractDigitalResource implements CaliperTargetable {
 
     @JsonProperty("currentTime")
     private String currentTime;
@@ -50,7 +50,7 @@ public class MediaLocation extends DigitalResource implements CaliperTargetable 
      * Builder class provides a fluid interface for setting object properties.
      * @param <T> builder
      */
-    public static abstract class Builder<T extends Builder<T>> extends DigitalResource.Builder<T>  {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractDigitalResource.Builder<T>  {
         private String currentTime;
 
         /**

--- a/src/main/java/org/imsglobal/caliper/entities/resource/MediaObject.java
+++ b/src/main/java/org/imsglobal/caliper/entities/resource/MediaObject.java
@@ -26,33 +26,20 @@ import javax.annotation.Nullable;
 /**
  * Concrete implementation of a generic MediaObject.
  */
-public class MediaObject extends DigitalResource implements CaliperMediaObject {
-
-    @JsonProperty("duration")
-    private String duration;
+public class MediaObject extends AbstractMediaObject implements CaliperMediaObject {
 
     /**
      * @param builder apply builder object properties to the MediaObject object.
      */
     protected MediaObject(Builder<?> builder) {
         super(builder);
-
-        this.duration = builder.duration;
-    }
-
-    /**
-     * @return duration
-     */
-    @Nullable
-    public String getDuration() {
-        return duration;
     }
 
     /**
      * Builder class provides a fluid interface for setting object properties.
      * @param <T> builder
      */
-    public static abstract class Builder<T extends Builder<T>> extends DigitalResource.Builder<T>  {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractMediaObject.Builder<T>  {
         private String duration;
 
         /**
@@ -60,15 +47,6 @@ public class MediaObject extends DigitalResource implements CaliperMediaObject {
          */
         public Builder() {
             super.type(EntityType.MEDIA_OBJECT);
-        }
-
-        /**
-         * @param duration
-         * @return duration
-         */
-        public T duration(String duration) {
-            this.duration = duration;
-            return self();
         }
 
         /**

--- a/src/main/java/org/imsglobal/caliper/entities/resource/Message.java
+++ b/src/main/java/org/imsglobal/caliper/entities/resource/Message.java
@@ -26,7 +26,7 @@ import org.imsglobal.caliper.entities.EntityType;
 import javax.annotation.Nullable;
 import java.util.List;
 
-public class Message extends DigitalResource {
+public class Message extends AbstractDigitalResource {
 
     @JsonProperty("replyTo")
     private final Message replyTo;
@@ -75,7 +75,7 @@ public class Message extends DigitalResource {
      * Builder class provides a fluid interface for setting object properties.
      * @param <T> builder.
      */
-    public static abstract class Builder<T extends Builder<T>> extends DigitalResource.Builder<T> {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractDigitalResource.Builder<T> {
         private Message replyTo;
         private String body;
         private List<CaliperDigitalResource> attachments = Lists.newArrayList();

--- a/src/main/java/org/imsglobal/caliper/entities/resource/Page.java
+++ b/src/main/java/org/imsglobal/caliper/entities/resource/Page.java
@@ -20,7 +20,7 @@ package org.imsglobal.caliper.entities.resource;
 
 import org.imsglobal.caliper.entities.EntityType;
 
-public class Page extends DigitalResource {
+public class Page extends AbstractDigitalResource {
 
     /**
      * @param builder apply builder object properties to the object.
@@ -33,7 +33,7 @@ public class Page extends DigitalResource {
      * Builder class provides a fluid interface for setting object properties.
      * @param <T> builder.
      */
-    public static abstract class Builder<T extends Builder<T>> extends DigitalResource.Builder<T> {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractDigitalResource.Builder<T> {
 
         /**
          * Constructor

--- a/src/main/java/org/imsglobal/caliper/entities/resource/Thread.java
+++ b/src/main/java/org/imsglobal/caliper/entities/resource/Thread.java
@@ -27,7 +27,7 @@ import org.imsglobal.caliper.entities.EntityType;
 import javax.annotation.Nullable;
 import java.util.List;
 
-public class Thread extends DigitalResource implements CaliperCollection<Message> {
+public class Thread extends AbstractDigitalResource implements CaliperCollection<Message> {
 
     @JsonProperty("items")
     private final ImmutableList<Message> items;
@@ -55,7 +55,7 @@ public class Thread extends DigitalResource implements CaliperCollection<Message
      * Builder class provides a fluid interface for setting object properties.
      * @param <T> builder.
      */
-    public static abstract class Builder<T extends Builder<T>> extends DigitalResource.Builder<T> {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractDigitalResource.Builder<T> {
         private List<Message> items = Lists.newArrayList();
 
         /**

--- a/src/main/java/org/imsglobal/caliper/entities/resource/VideoObject.java
+++ b/src/main/java/org/imsglobal/caliper/entities/resource/VideoObject.java
@@ -25,7 +25,7 @@ import javax.annotation.Nullable;
 /**
  * A Video object embedded in a web page.
  */
-public class VideoObject extends MediaObject {
+public class VideoObject extends AbstractMediaObject implements CaliperMediaObject {
 
     /**
      * @param builder apply builder object properties to the VideoObject object.
@@ -38,7 +38,7 @@ public class VideoObject extends MediaObject {
      * Builder class provides a fluid interface for setting object properties.
      * @param <T> builder
      */
-    public static abstract class Builder<T extends Builder<T>> extends MediaObject.Builder<T>  {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractMediaObject.Builder<T>  {
 
         /**
          * Initialize type with default value.  Required if builder().type() is not set by user.

--- a/src/main/java/org/imsglobal/caliper/entities/resource/WebPage.java
+++ b/src/main/java/org/imsglobal/caliper/entities/resource/WebPage.java
@@ -20,7 +20,7 @@ package org.imsglobal.caliper.entities.resource;
 
 import org.imsglobal.caliper.entities.EntityType;
 
-public class WebPage extends DigitalResource {
+public class WebPage extends AbstractDigitalResource {
 
     /**
      * @param builder apply builder object properties to the object.
@@ -33,7 +33,7 @@ public class WebPage extends DigitalResource {
      * Builder class provides a fluid interface for setting object properties.
      * @param <T> builder.
      */
-    public static abstract class Builder<T extends Builder<T>> extends DigitalResource.Builder<T> {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractDigitalResource.Builder<T> {
 
         /**
          * Constructor

--- a/src/main/java/org/imsglobal/caliper/entities/response/FillinBlankResponse.java
+++ b/src/main/java/org/imsglobal/caliper/entities/response/FillinBlankResponse.java
@@ -29,7 +29,7 @@ import java.util.List;
  * Represents response text or integer/decimal/scientific numbers that completes a question
  * designed with one or more "fill in the blank" option prompts.
  */
-public class FillinBlankResponse extends Response {
+public class FillinBlankResponse extends AbstractResponse {
 
     @JsonProperty("values")
     private ImmutableList<String> values;
@@ -54,7 +54,7 @@ public class FillinBlankResponse extends Response {
      * Builder class provides a fluid interface for setting object properties.
      * @param <T> builder
      */
-    public static abstract class Builder<T extends Builder<T>> extends Response.Builder<T>  {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractResponse.Builder<T>  {
         private List<String> values = Lists.newArrayList();
 
         /**

--- a/src/main/java/org/imsglobal/caliper/entities/response/MultipleChoiceResponse.java
+++ b/src/main/java/org/imsglobal/caliper/entities/response/MultipleChoiceResponse.java
@@ -25,7 +25,7 @@ import javax.annotation.Nullable;
 /**
  * Represents a response to a multiple choice question that permits a single option to be selected.
  */
-public class MultipleChoiceResponse extends Response {
+public class MultipleChoiceResponse extends AbstractResponse {
 
     @JsonProperty("value")
     private String value;
@@ -50,7 +50,7 @@ public class MultipleChoiceResponse extends Response {
      * Builder class provides a fluid interface for setting object properties.
      * @param <T> builder
      */
-    public static abstract class Builder<T extends Builder<T>> extends Response.Builder<T>  {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractResponse.Builder<T>  {
         private String value;
 
         /**

--- a/src/main/java/org/imsglobal/caliper/entities/response/MultipleResponseResponse.java
+++ b/src/main/java/org/imsglobal/caliper/entities/response/MultipleResponseResponse.java
@@ -30,7 +30,7 @@ import java.util.List;
  * Representation of a response to a multiple choice question that permits one or more
  * options to be selected.
  */
-public class MultipleResponseResponse extends Response {
+public class MultipleResponseResponse extends AbstractResponse {
 
     @JsonProperty("values")
     private ImmutableList<String> values;
@@ -55,7 +55,7 @@ public class MultipleResponseResponse extends Response {
      * Builder class provides a fluid interface for setting object properties.
      * @param <T> builder
      */
-    public static abstract class Builder<T extends Builder<T>> extends Response.Builder<T>  {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractResponse.Builder<T>  {
         private List<String> values = Lists.newArrayList();
         private TimePeriod timePeriod = new TimePeriod();
 

--- a/src/main/java/org/imsglobal/caliper/entities/response/SelectTextResponse.java
+++ b/src/main/java/org/imsglobal/caliper/entities/response/SelectTextResponse.java
@@ -29,7 +29,7 @@ import java.util.List;
  *  Represents a response that identifies text from a presented paragraph or list.
  *  The response is the identified string or a mapping to a logical identifier;
  */
-public class SelectTextResponse extends Response {
+public class SelectTextResponse extends AbstractResponse {
 
     @JsonProperty("values")
     private ImmutableList<String> values;
@@ -54,7 +54,7 @@ public class SelectTextResponse extends Response {
      * Builder class provides a fluid interface for setting object properties.
      * @param <T> builder
      */
-    public static abstract class Builder<T extends Builder<T>> extends Response.Builder<T>  {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractResponse.Builder<T>  {
         private List<String> values = Lists.newArrayList();
 
         /**

--- a/src/main/java/org/imsglobal/caliper/entities/response/TrueFalseResponse.java
+++ b/src/main/java/org/imsglobal/caliper/entities/response/TrueFalseResponse.java
@@ -26,7 +26,7 @@ import javax.annotation.Nullable;
  * Represents response to a multiple choice question that limits options to either 'true or false',
  * 'agree or disagree', etc.
  */
-public class TrueFalseResponse extends Response {
+public class TrueFalseResponse extends AbstractResponse {
 
     @JsonProperty("value")
     private String value;
@@ -51,7 +51,7 @@ public class TrueFalseResponse extends Response {
      * Builder class provides a fluid interface for setting object properties.
      * @param <T> builder
      */
-    public static abstract class Builder<T extends Builder<T>> extends Response.Builder<T>  {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractResponse.Builder<T>  {
         private String value;
 
         /**

--- a/src/main/java/org/imsglobal/caliper/entities/scale/LikertScale.java
+++ b/src/main/java/org/imsglobal/caliper/entities/scale/LikertScale.java
@@ -22,13 +22,14 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import org.imsglobal.caliper.entities.AbstractEntity;
 import org.imsglobal.caliper.entities.Entity;
 import org.imsglobal.caliper.entities.EntityType;
 
 import javax.annotation.Nullable;
 import java.util.List;
 
-public class LikertScale extends Entity implements CaliperScale {
+public class LikertScale extends AbstractEntity implements CaliperScale {
 
     @JsonProperty("itemLabels")
     private final ImmutableList<String> itemLabels;
@@ -78,7 +79,7 @@ public class LikertScale extends Entity implements CaliperScale {
      * Builder class provides a fluid interface for setting object properties.
      * @param <T> builder.
      */
-    public static abstract class Builder<T extends Builder<T>> extends Entity.Builder<T> {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractEntity.Builder<T> {
         private List<String> itemLabels = Lists.newArrayList();
         private List<String> itemValues = Lists.newArrayList();
         private int scalePoints;

--- a/src/main/java/org/imsglobal/caliper/entities/scale/MultiselectScale.java
+++ b/src/main/java/org/imsglobal/caliper/entities/scale/MultiselectScale.java
@@ -22,13 +22,14 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import org.imsglobal.caliper.entities.AbstractEntity;
 import org.imsglobal.caliper.entities.Entity;
 import org.imsglobal.caliper.entities.EntityType;
 
 import javax.annotation.Nullable;
 import java.util.List;
 
-public class MultiselectScale extends Entity implements CaliperScale {
+public class MultiselectScale extends AbstractEntity implements CaliperScale {
 
     @JsonProperty("isOrderedSelection")
     private final boolean isOrderedSelection;
@@ -119,7 +120,7 @@ public class MultiselectScale extends Entity implements CaliperScale {
      * Builder class provides a fluid interface for setting object properties.
      * @param <T> builder.
      */
-    public static abstract class Builder<T extends Builder<T>> extends Entity.Builder<T> {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractEntity.Builder<T> {
         private boolean isOrderedSelection;
         private List<String> itemLabels = Lists.newArrayList();
         private List<String> itemValues = Lists.newArrayList();

--- a/src/main/java/org/imsglobal/caliper/entities/scale/NumericScale.java
+++ b/src/main/java/org/imsglobal/caliper/entities/scale/NumericScale.java
@@ -20,12 +20,13 @@ package org.imsglobal.caliper.entities.scale;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.imsglobal.caliper.entities.AbstractEntity;
 import org.imsglobal.caliper.entities.Entity;
 import org.imsglobal.caliper.entities.EntityType;
 
 import javax.annotation.Nullable;
 
-public class NumericScale extends Entity implements CaliperScale {
+public class NumericScale extends AbstractEntity implements CaliperScale {
 
     @JsonProperty("maxLabel")
     private final String maxLabel;
@@ -103,7 +104,7 @@ public class NumericScale extends Entity implements CaliperScale {
      * Builder class provides a fluid interface for setting object properties.
      * @param <T> builder.
      */
-    public static abstract class Builder<T extends Builder<T>> extends Entity.Builder<T> {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractEntity.Builder<T> {
         private String maxLabel;
         private String minLabel;
         private double maxValue;

--- a/src/main/java/org/imsglobal/caliper/entities/scale/Scale.java
+++ b/src/main/java/org/imsglobal/caliper/entities/scale/Scale.java
@@ -22,7 +22,7 @@ import org.imsglobal.caliper.entities.AbstractEntity;
 import org.imsglobal.caliper.entities.Entity;
 import org.imsglobal.caliper.entities.EntityType;
 
-public class Scale extends Entity implements CaliperScale {
+public class Scale extends AbstractEntity implements CaliperScale {
 
     /**
      * @param builder apply builder object properties to the object.
@@ -35,7 +35,7 @@ public class Scale extends Entity implements CaliperScale {
      * Builder class provides a fluid interface for setting object properties.
      * @param <T> builder.
      */
-    public static abstract class Builder<T extends Builder<T>> extends Entity.Builder<T> {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractEntity.Builder<T> {
 
         /**
          * Constructor

--- a/src/main/java/org/imsglobal/caliper/entities/search/Query.java
+++ b/src/main/java/org/imsglobal/caliper/entities/search/Query.java
@@ -19,15 +19,12 @@
 package org.imsglobal.caliper.entities.search;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.imsglobal.caliper.entities.CaliperEntity;
-import org.imsglobal.caliper.entities.CaliperGeneratable;
-import org.imsglobal.caliper.entities.Entity;
-import org.imsglobal.caliper.entities.EntityType;
+import org.imsglobal.caliper.entities.*;
 import org.imsglobal.caliper.entities.agent.Person;
 
 import javax.annotation.Nullable;
 
-public class Query extends Entity {
+public class Query extends AbstractEntity {
 
     @JsonProperty("creator")
     private final Person creator;
@@ -76,7 +73,7 @@ public class Query extends Entity {
      * Builder class provides a fluid interface for setting object properties.
      * @param <T> builder.
      */
-    public static abstract class Builder<T extends Builder<T>> extends Entity.Builder<T> {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractEntity.Builder<T> {
         private Person creator;
         private CaliperEntity searchTarget;
         private String searchTerms;

--- a/src/main/java/org/imsglobal/caliper/entities/search/SearchResponse.java
+++ b/src/main/java/org/imsglobal/caliper/entities/search/SearchResponse.java
@@ -27,7 +27,7 @@ import org.imsglobal.caliper.entities.agent.SoftwareApplication;
 import javax.annotation.Nullable;
 import java.util.List;
 
-public class SearchResponse extends Entity implements CaliperGeneratable {
+public class SearchResponse extends AbstractEntity implements CaliperGeneratable {
 
     @JsonProperty("searchProvider")
     private final SoftwareApplication searchProvider;
@@ -100,7 +100,7 @@ public class SearchResponse extends Entity implements CaliperGeneratable {
      * Builder class provides a fluid interface for setting object properties.
      * @param <T> builder.
      */
-    public static abstract class Builder<T extends Builder<T>> extends Entity.Builder<T> {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractEntity.Builder<T> {
         private SoftwareApplication searchProvider;
         private CaliperEntity searchTarget;
         private Query query;

--- a/src/main/java/org/imsglobal/caliper/entities/session/LtiSession.java
+++ b/src/main/java/org/imsglobal/caliper/entities/session/LtiSession.java
@@ -23,7 +23,7 @@ import org.imsglobal.caliper.entities.AbstractEntity;
 import org.imsglobal.caliper.entities.EntityType;
 import javax.annotation.Nullable;
 
-public class LtiSession extends Session {
+public class LtiSession extends AbstractSession {
 
     @JsonProperty("messageParameters")
     private final Object messageParameters;
@@ -48,7 +48,7 @@ public class LtiSession extends Session {
      * Builder class provides a fluid interface for setting object properties.
      * @param <T> builder
      */
-    public static abstract class Builder<T extends Builder<T>> extends Session.Builder<T>  {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractSession.Builder<T>  {
         private Object messageParameters;
 
         /**

--- a/src/main/java/org/imsglobal/caliper/entities/survey/Comment.java
+++ b/src/main/java/org/imsglobal/caliper/entities/survey/Comment.java
@@ -20,15 +20,12 @@ package org.imsglobal.caliper.entities.survey;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.imsglobal.caliper.entities.CaliperEntity;
-import org.imsglobal.caliper.entities.CaliperGeneratable;
-import org.imsglobal.caliper.entities.Entity;
-import org.imsglobal.caliper.entities.EntityType;
+import org.imsglobal.caliper.entities.*;
 import org.imsglobal.caliper.entities.agent.Person;
 
 import javax.annotation.Nullable;
 
-public class Comment extends Entity implements CaliperGeneratable {
+public class Comment extends AbstractEntity implements CaliperGeneratable {
 
     @JsonProperty("commenter")
     private final Person commenter;
@@ -71,7 +68,7 @@ public class Comment extends Entity implements CaliperGeneratable {
      * Builder class provides a fluid interface for setting object properties.
      * @param <T> builder.
      */
-    public static abstract class Builder<T extends Builder<T>> extends Entity.Builder<T> {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractEntity.Builder<T> {
         private Person commenter;
         private CaliperEntity commentedOn;
         private String value;

--- a/src/main/java/org/imsglobal/caliper/entities/survey/Rating.java
+++ b/src/main/java/org/imsglobal/caliper/entities/survey/Rating.java
@@ -22,16 +22,13 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import org.imsglobal.caliper.entities.CaliperEntity;
-import org.imsglobal.caliper.entities.CaliperGeneratable;
-import org.imsglobal.caliper.entities.Entity;
-import org.imsglobal.caliper.entities.EntityType;
+import org.imsglobal.caliper.entities.*;
 import org.imsglobal.caliper.entities.agent.Person;
 
 import javax.annotation.Nullable;
 import java.util.List;
 
-public class Rating extends Entity implements CaliperGeneratable {
+public class Rating extends AbstractEntity implements CaliperGeneratable {
 
     @JsonProperty("question")
     private final CaliperQuestion question;
@@ -97,7 +94,7 @@ public class Rating extends Entity implements CaliperGeneratable {
      * Builder class provides a fluid interface for setting object properties.
      * @param <T> builder.
      */
-    public static abstract class Builder<T extends Builder<T>> extends Entity.Builder<T> {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractEntity.Builder<T> {
         private CaliperQuestion question;
         private Person rater;
         private CaliperEntity rated;

--- a/src/main/java/org/imsglobal/caliper/entities/use/AggregateMeasure.java
+++ b/src/main/java/org/imsglobal/caliper/entities/use/AggregateMeasure.java
@@ -21,6 +21,7 @@ package org.imsglobal.caliper.entities.use;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.imsglobal.caliper.entities.AbstractEntity;
 import org.imsglobal.caliper.entities.Entity;
 import org.imsglobal.caliper.entities.EntityType;
 import org.imsglobal.caliper.entities.TimePeriod;
@@ -32,7 +33,7 @@ import javax.annotation.Nullable;
 /**
  * Representation of an AggregateMeasure.
  */
-public class AggregateMeasure extends Entity {
+public class AggregateMeasure extends AbstractEntity {
 
     @JsonProperty("metric")
     private CaliperMetric metric;
@@ -107,7 +108,7 @@ public class AggregateMeasure extends Entity {
      * Builder class provides a fluid interface for setting object properties.
      * @param <T> builder.
      */
-    public static abstract class Builder<T extends Builder<T>> extends Entity.Builder<T> {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractEntity.Builder<T> {
         private CaliperMetric metric;
         private double metricValue;
         private double maxMetricValue;

--- a/src/main/java/org/imsglobal/caliper/entities/use/AggregateMeasureCollection.java
+++ b/src/main/java/org/imsglobal/caliper/entities/use/AggregateMeasureCollection.java
@@ -26,7 +26,7 @@ import org.imsglobal.caliper.entities.*;
 import javax.annotation.Nullable;
 import java.util.List;
 
-public class AggregateMeasureCollection extends Entity implements CaliperCollection<AggregateMeasure>, CaliperGeneratable {
+public class AggregateMeasureCollection extends AbstractEntity implements CaliperCollection<AggregateMeasure>, CaliperGeneratable {
 
     @JsonProperty("items")
     private final ImmutableList<AggregateMeasure> items;
@@ -53,7 +53,7 @@ public class AggregateMeasureCollection extends Entity implements CaliperCollect
      * Builder class provides a fluid interface for setting object properties.
      * @param <T> builder.
      */
-    public static abstract class Builder<T extends Builder<T>> extends Entity.Builder<T> {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractEntity.Builder<T> {
         private List<AggregateMeasure> items = Lists.newArrayList();
 
         /**

--- a/src/main/java/org/imsglobal/caliper/events/AnnotationEvent.java
+++ b/src/main/java/org/imsglobal/caliper/events/AnnotationEvent.java
@@ -37,7 +37,7 @@ import javax.annotation.Nullable;
     Action.SHARED,
     Action.TAGGED
 })
-public class AnnotationEvent extends Event {
+public class AnnotationEvent extends AbstractEvent {
 
     @JsonProperty("actor")
     private final Person actor;
@@ -104,7 +104,7 @@ public class AnnotationEvent extends Event {
      * Initialize default parameter values in the builder.
      * @param <T> builder
      */
-    public static abstract class Builder<T extends Builder<T>> extends Event.Builder<T>  {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractEvent.Builder<T>  {
         private Person actor;
         private CaliperDigitalResource object;
         private CaliperAnnotation generated;

--- a/src/main/java/org/imsglobal/caliper/events/AssessmentEvent.java
+++ b/src/main/java/org/imsglobal/caliper/events/AssessmentEvent.java
@@ -38,7 +38,7 @@ import javax.annotation.Nullable;
     Action.RESUMED,
     Action.SUBMITTED
 })
-public class AssessmentEvent extends Event {
+public class AssessmentEvent extends AbstractEvent {
 
     @JsonProperty("actor")
     private final Person actor;
@@ -105,7 +105,7 @@ public class AssessmentEvent extends Event {
      * Initialize default parameter values in the builder.
      * @param <T> builder
      */
-    public static abstract class Builder<T extends Builder<T>> extends Event.Builder<T>  {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractEvent.Builder<T>  {
         private Person actor;
         private Assessment object;
         private Attempt generated;

--- a/src/main/java/org/imsglobal/caliper/events/AssessmentItemEvent.java
+++ b/src/main/java/org/imsglobal/caliper/events/AssessmentItemEvent.java
@@ -36,7 +36,7 @@ import javax.annotation.Nonnull;
     Action.COMPLETED,
     Action.SKIPPED
 })
-public class AssessmentItemEvent extends Event {
+public class AssessmentItemEvent extends AbstractEvent {
 
     @JsonProperty("actor")
     private final Person actor;
@@ -97,7 +97,7 @@ public class AssessmentItemEvent extends Event {
      * Initialize default parameter values in the builder.
      * @param <T> builder
      */
-    public static abstract class Builder<T extends Builder<T>> extends Event.Builder<T>  {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractEvent.Builder<T>  {
         private Person actor;
         private AssessmentItem object;
 

--- a/src/main/java/org/imsglobal/caliper/events/AssignableEvent.java
+++ b/src/main/java/org/imsglobal/caliper/events/AssignableEvent.java
@@ -36,7 +36,7 @@ import javax.annotation.Nonnull;
     Action.STARTED,
     Action.SUBMITTED
 })
-public class AssignableEvent extends Event {
+public class AssignableEvent extends AbstractEvent {
 
     @JsonProperty("object")
     private final CaliperAssignable object;
@@ -75,7 +75,7 @@ public class AssignableEvent extends Event {
      * Initialize default parameter values in the builder.
      * @param <T> builder
      */
-    public static abstract class Builder<T extends Builder<T>> extends Event.Builder<T>  {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractEvent.Builder<T>  {
         private CaliperAssignable object;
 
         /*

--- a/src/main/java/org/imsglobal/caliper/events/FeedbackEvent.java
+++ b/src/main/java/org/imsglobal/caliper/events/FeedbackEvent.java
@@ -32,7 +32,7 @@ import javax.annotation.Nonnull;
     Action.COMMENTED,
     Action.RANKED
 })
-public class FeedbackEvent extends Event {
+public class FeedbackEvent extends AbstractEvent {
 
     @JsonProperty("actor")
     private final Person actor;
@@ -71,7 +71,7 @@ public class FeedbackEvent extends Event {
      * Initialize default parameter values in the builder.
      * @param <T> builder
      */
-    public static abstract class Builder<T extends Builder<T>> extends Event.Builder<T>  {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractEvent.Builder<T>  {
         private Person actor;
 
         /*

--- a/src/main/java/org/imsglobal/caliper/events/ForumEvent.java
+++ b/src/main/java/org/imsglobal/caliper/events/ForumEvent.java
@@ -33,7 +33,7 @@ import javax.annotation.Nonnull;
     Action.SUBSCRIBED,
     Action.UNSUBSCRIBED
 })
-public class ForumEvent extends Event {
+public class ForumEvent extends AbstractEvent {
 
     @JsonProperty("actor")
     private final Person actor;
@@ -86,7 +86,7 @@ public class ForumEvent extends Event {
      * Initialize default parameter values in the builder.
      * @param <T> builder
      */
-    public static abstract class Builder<T extends Builder<T>> extends Event.Builder<T>  {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractEvent.Builder<T>  {
         private Person actor;
         private Forum object;
 

--- a/src/main/java/org/imsglobal/caliper/events/GradeEvent.java
+++ b/src/main/java/org/imsglobal/caliper/events/GradeEvent.java
@@ -31,7 +31,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 @SupportedActions({ Action.GRADED })
-public class GradeEvent extends Event {
+public class GradeEvent extends AbstractEvent {
 
     @JsonProperty("object")
     private final Attempt object;
@@ -84,7 +84,7 @@ public class GradeEvent extends Event {
      * Initialize default parameter values in the builder.
      * @param <T> builder
      */
-    public static abstract class Builder<T extends Builder<T>> extends Event.Builder<T>  {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractEvent.Builder<T>  {
         private Attempt object;
         private Score generated;
 

--- a/src/main/java/org/imsglobal/caliper/events/MediaEvent.java
+++ b/src/main/java/org/imsglobal/caliper/events/MediaEvent.java
@@ -51,7 +51,7 @@ import javax.annotation.Nonnull;
     Action.MUTED,
     Action.UNMUTED
 })
-public class MediaEvent extends Event {
+public class MediaEvent extends AbstractEvent {
 
     @JsonProperty("actor")
     private final Person actor;
@@ -105,7 +105,7 @@ public class MediaEvent extends Event {
      * Initialize default parameter values in the builder.
      * @param <T> builder
      */
-    public static abstract class Builder<T extends Builder<T>> extends Event.Builder<T>  {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractEvent.Builder<T>  {
         private Person actor;
         private CaliperMediaObject object;
 

--- a/src/main/java/org/imsglobal/caliper/events/MessageEvent.java
+++ b/src/main/java/org/imsglobal/caliper/events/MessageEvent.java
@@ -34,7 +34,7 @@ import javax.annotation.Nonnull;
     Action.MARKED_AS_UNREAD,
     Action.POSTED
 })
-public class MessageEvent extends Event {
+public class MessageEvent extends AbstractEvent {
 
     @JsonProperty("actor")
     private final Person actor;
@@ -87,7 +87,7 @@ public class MessageEvent extends Event {
      * Initialize default parameter values in the builder.
      * @param <T> builder
      */
-    public static abstract class Builder<T extends Builder<T>> extends Event.Builder<T>  {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractEvent.Builder<T>  {
         private Person actor;
         private Message object;
 

--- a/src/main/java/org/imsglobal/caliper/events/NavigationEvent.java
+++ b/src/main/java/org/imsglobal/caliper/events/NavigationEvent.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nonnull;
 
 @SupportedActions({ Action.NAVIGATED_TO })
-public class NavigationEvent extends Event {
+public class NavigationEvent extends AbstractEvent {
 
     @JsonProperty("actor")
     private final Person actor;
@@ -68,7 +68,7 @@ public class NavigationEvent extends Event {
      * Initialize default parameter values in the builder.
      * @param <T> builder
      */
-    public static abstract class Builder<T extends Builder<T>> extends Event.Builder<T>  {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractEvent.Builder<T>  {
         private Person actor;
 
         /*

--- a/src/main/java/org/imsglobal/caliper/events/ResourceManagementEvent.java
+++ b/src/main/java/org/imsglobal/caliper/events/ResourceManagementEvent.java
@@ -45,7 +45,7 @@ import javax.annotation.Nonnull;
     Action.UNPUBLISHED,
     Action.UPLOADED
 })
-public class ResourceManagementEvent extends Event {
+public class ResourceManagementEvent extends AbstractEvent {
 
     @JsonProperty("actor")
     private final Person actor;
@@ -112,7 +112,7 @@ public class ResourceManagementEvent extends Event {
      * Initialize default parameter values in the builder.
      * @param <T> builder
      */
-    public static abstract class Builder<T extends Builder<T>> extends Event.Builder<T>  {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractEvent.Builder<T>  {
         private Person actor;
         private CaliperDigitalResource object;
         private CaliperDigitalResource generated;

--- a/src/main/java/org/imsglobal/caliper/events/SearchEvent.java
+++ b/src/main/java/org/imsglobal/caliper/events/SearchEvent.java
@@ -31,7 +31,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 @SupportedActions({ Action.SEARCHED })
-public class SearchEvent extends Event {
+public class SearchEvent extends AbstractEvent {
 
     @JsonProperty("actor")
     private final Person actor;
@@ -84,7 +84,7 @@ public class SearchEvent extends Event {
      * Initialize default parameter values in the builder.
      * @param <T> builder
      */
-    public static abstract class Builder<T extends Builder<T>> extends Event.Builder<T>  {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractEvent.Builder<T>  {
         private Person actor;
         private SearchResponse generated;
 

--- a/src/main/java/org/imsglobal/caliper/events/SessionEvent.java
+++ b/src/main/java/org/imsglobal/caliper/events/SessionEvent.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
         Action.LOGGED_OUT,
         Action.TIMED_OUT
 })
-public class SessionEvent extends Event {
+public class SessionEvent extends AbstractEvent {
 
     @JsonIgnore
     private static final Logger log = LoggerFactory.getLogger(SessionEvent.class);
@@ -76,7 +76,7 @@ public class SessionEvent extends Event {
      * Initialize default parameter values in the builder.
      * @param <T> builder
      */
-    public static abstract class Builder<T extends Builder<T>> extends Event.Builder<T>  {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractEvent.Builder<T>  {
 
         /*
          * Constructor

--- a/src/main/java/org/imsglobal/caliper/events/ThreadEvent.java
+++ b/src/main/java/org/imsglobal/caliper/events/ThreadEvent.java
@@ -33,7 +33,7 @@ import javax.annotation.Nonnull;
     Action.MARKED_AS_READ,
     Action.MARKED_AS_UNREAD
 })
-public class ThreadEvent extends Event {
+public class ThreadEvent extends AbstractEvent {
 
     @JsonProperty("actor")
     private final Person actor;
@@ -86,7 +86,7 @@ public class ThreadEvent extends Event {
      * Initialize default parameter values in the builder.
      * @param <T> builder
      */
-    public static abstract class Builder<T extends Builder<T>> extends Event.Builder<T>  {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractEvent.Builder<T>  {
         private Person actor;
         private Thread object;
 

--- a/src/main/java/org/imsglobal/caliper/events/ToolUseEvent.java
+++ b/src/main/java/org/imsglobal/caliper/events/ToolUseEvent.java
@@ -34,7 +34,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 @SupportedActions({Action.USED})
-public class ToolUseEvent extends Event {
+public class ToolUseEvent extends AbstractEvent {
 
     @JsonProperty("actor")
     private final Person actor;
@@ -102,7 +102,7 @@ public class ToolUseEvent extends Event {
      * Initialize default parameter values in the builder.
      * @param <T> builder
      */
-    public static abstract class Builder<T extends Builder<T>> extends Event.Builder<T>  {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractEvent.Builder<T>  {
         private Person actor;
         private SoftwareApplication object;
         private AggregateMeasureCollection generated;

--- a/src/main/java/org/imsglobal/caliper/events/ViewEvent.java
+++ b/src/main/java/org/imsglobal/caliper/events/ViewEvent.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nonnull;
 
 @SupportedActions({ Action.VIEWED })
-public class ViewEvent extends Event {
+public class ViewEvent extends AbstractEvent {
 
     @JsonProperty("actor")
     private final Person actor;
@@ -83,7 +83,7 @@ public class ViewEvent extends Event {
      * Initialize default parameter values in the builder.
      * @param <T> builder
      */
-    public static abstract class Builder<T extends Builder<T>> extends Event.Builder<T>  {
+    public static abstract class Builder<T extends Builder<T>> extends AbstractEvent.Builder<T>  {
         private Person actor;
         private CaliperDigitalResource object;
 

--- a/src/test/java/org/imsglobal/caliper/v1p1/entities/DigitalResourceCollectionTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p1/entities/DigitalResourceCollectionTest.java
@@ -16,7 +16,7 @@
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package org.imsglobal.caliper.v1p2.entities;
+package org.imsglobal.caliper.v1p1.entities;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
@@ -28,7 +28,6 @@ import org.imsglobal.caliper.entities.agent.CourseOffering;
 import org.imsglobal.caliper.entities.agent.CourseSection;
 import org.imsglobal.caliper.entities.agent.Person;
 import org.imsglobal.caliper.entities.resource.CaliperDigitalResource;
-import org.imsglobal.caliper.entities.resource.DigitalResource;
 import org.imsglobal.caliper.entities.resource.DigitalResourceCollection;
 import org.imsglobal.caliper.entities.resource.VideoObject;
 import org.joda.time.DateTime;
@@ -81,7 +80,6 @@ public class DigitalResourceCollectionTest {
             .id(BASE_IRI.concat("/videos/1225"))
             .mediaType("video/ogg")
             .name("Introduction to IMS Caliper")
-            .storageName("caliper-intro.ogg")
             .dateCreated(new DateTime(2016, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
             .duration("PT1H12M27S")
             .version("1.1")
@@ -91,7 +89,6 @@ public class DigitalResourceCollectionTest {
             .id(BASE_IRI.concat("/videos/5629"))
             .mediaType("video/ogg")
             .name("IMS Caliper Activity Profiles")
-            .storageName("caliper-activity-profiles.ogg")
             .dateCreated(new DateTime(2016, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
             .duration("PT55M13S")
             .version("1.1.1")
@@ -102,7 +99,7 @@ public class DigitalResourceCollectionTest {
         resources.add(video2);
 
         entity = DigitalResourceCollection.builder()
-            .context(JsonldStringContext.create(CaliperJsonldContext.V1P2.value()))
+            .context(JsonldStringContext.create(CaliperJsonldContext.V1P1.value()))
             .id(SECTION_IRI.concat("/resources/2"))
             .name("Video Collection")
             .keywords(keywords)
@@ -118,7 +115,7 @@ public class DigitalResourceCollectionTest {
         ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
         String json = mapper.writeValueAsString(entity);
 
-        String fixture = jsonFixture("fixtures/v1p2/caliperEntityDigitalResourceCollection.json");
+        String fixture = jsonFixture("fixtures/v1p1/caliperEntityDigitalResourceCollection.json");
         JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
     }
 

--- a/src/test/java/org/imsglobal/caliper/v1p1/entities/DigitalResourceTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p1/entities/DigitalResourceTest.java
@@ -16,7 +16,7 @@
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package org.imsglobal.caliper.v1p2.entities;
+package org.imsglobal.caliper.v1p1.entities;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
@@ -24,13 +24,10 @@ import org.imsglobal.caliper.TestUtils;
 import org.imsglobal.caliper.context.CaliperJsonldContext;
 import org.imsglobal.caliper.context.JsonldStringContext;
 import org.imsglobal.caliper.entities.agent.CaliperAgent;
-import org.imsglobal.caliper.entities.agent.CourseOffering;
 import org.imsglobal.caliper.entities.agent.CourseSection;
 import org.imsglobal.caliper.entities.agent.Person;
-import org.imsglobal.caliper.entities.resource.CaliperDigitalResource;
 import org.imsglobal.caliper.entities.resource.DigitalResource;
 import org.imsglobal.caliper.entities.resource.DigitalResourceCollection;
-import org.imsglobal.caliper.entities.resource.VideoObject;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.After;
@@ -45,71 +42,44 @@ import java.util.List;
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
 @Category(org.imsglobal.caliper.UnitTest.class)
-public class DigitalResourceCollectionTest {
+public class DigitalResourceTest {
     private DigitalResourceCollection collection;
-    private CourseOffering course;
     private CourseSection section;
     private Person actor;
     private List<CaliperAgent> creators;
-    private List<CaliperDigitalResource> resources;
-    private List<String> keywords;
-    private DigitalResourceCollection entity;
-    private VideoObject video1;
-    private VideoObject video2;
+    private DigitalResource entity;
 
     private static final String BASE_IRI = "https://example.edu";
-    private static final String COURSE_IRI = BASE_IRI.concat("/terms/201601/courses/7");
     private static final String SECTION_IRI = BASE_IRI.concat("/terms/201601/courses/7/sections/1");
 
     @Before
     public void setUp() throws Exception {
-        
-        keywords = Lists.newArrayList();
-        keywords.add("collection");
-        keywords.add("videos");
 
-        course = CourseOffering.builder()
-            .id(COURSE_IRI)
+        actor = Person.builder()
+            .id(BASE_IRI.concat("/users/223344"))
             .build();
+
+        creators = Lists.newArrayList();
+        creators.add(actor);
 
         section = CourseSection.builder()
             .id(SECTION_IRI)
-            .subOrganizationOf(course)
             .build();
 
-        video1 = VideoObject.builder()
-            .id(BASE_IRI.concat("/videos/1225"))
-            .mediaType("video/ogg")
-            .name("Introduction to IMS Caliper")
-            .storageName("caliper-intro.ogg")
-            .dateCreated(new DateTime(2016, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
-            .duration("PT1H12M27S")
-            .version("1.1")
-            .build();
-
-        video2 = VideoObject.builder()
-            .id(BASE_IRI.concat("/videos/5629"))
-            .mediaType("video/ogg")
-            .name("IMS Caliper Activity Profiles")
-            .storageName("caliper-activity-profiles.ogg")
-            .dateCreated(new DateTime(2016, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
-            .duration("PT55M13S")
-            .version("1.1.1")
-            .build();
-
-        resources = Lists.newArrayList();
-        resources.add(video1);
-        resources.add(video2);
-
-        entity = DigitalResourceCollection.builder()
-            .context(JsonldStringContext.create(CaliperJsonldContext.V1P2.value()))
-            .id(SECTION_IRI.concat("/resources/2"))
-            .name("Video Collection")
-            .keywords(keywords)
-            .items(resources)
+        collection = DigitalResourceCollection.builder()
+            .id(SECTION_IRI.concat("/resources/1"))
+            .name("Course Assets")
             .isPartOf(section)
-            .dateCreated(new DateTime(2016, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
-            .dateModified(new DateTime(2016, 9, 2, 11, 30, 0, 0, DateTimeZone.UTC))
+            .build();
+
+        entity = DigitalResource.builder()
+            .context(JsonldStringContext.create(CaliperJsonldContext.V1P1.value()))
+            .id(SECTION_IRI.concat("/resources/1/syllabus.pdf"))
+            .name("Course Syllabus")
+            .mediaType("application/pdf")
+            .creators(creators)
+            .isPartOf(collection)
+            .dateCreated(new DateTime(2016, 8, 2, 11, 32, 0, 0, DateTimeZone.UTC))
             .build();
     }
 
@@ -118,7 +88,7 @@ public class DigitalResourceCollectionTest {
         ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
         String json = mapper.writeValueAsString(entity);
 
-        String fixture = jsonFixture("fixtures/v1p2/caliperEntityDigitalResourceCollection.json");
+        String fixture = jsonFixture("fixtures/v1p1/caliperEntityDigitalResource.json");
         JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
     }
 


### PR DESCRIPTION
Refactor Event and Entity concrete classes to extend not from one another but from the appropriate abstract class that provides a skeletal implementation available for use.  Doing this not only shortens the inheritance chain but provides a common pattern implemented previously inconsistently in caliper-java.

This PR also adds two entity tests to the set of v1p1 tests:

* caliperDigitalResourceCollectionTest
* caliperDigitalResourceTest

This PR also fixes a bug in the v1p2 caliperCollectionTest.