### PR TITLE
Update README instructions regarding fixtures location; Remove SearchResponse.searchResults

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ local development machine.
 documentation and reporting.
 
 ### Building
-First, clone the *caliper-common-fixtures* project to your development machine and add symbolic 
-links: 
+First, clone the *caliper-spec* project to your development machine. Checkout the `develop` branch. Then 
+and add symbolic links for the v1p1 and v1p2 fixtures: 
 
 ```
-ln -s /Path/to/caliper-common-fixtures/v1p0 src/test/resources/fixtures/v1p0
-ln -s /Path/to/caliper-common-fixtures/v1p1 src/test/resources/fixtures/v1p1
-ln -s /Path/to/caliper-common-fixtures/v1p2 src/test/resources/fixtures/v1p2
+ln -s /Path/to/caliper-spec/fixtures/v1p0 src/test/resources/fixtures/v1p0
+ln -s /Path/to/caliper-spec/fixtures/v1p1 src/test/resources/fixtures/v1p1
+ln -s /Path/to/caliper-spec/fixtures/v1p2 src/test/resources/fixtures/v1p2
 ``` 
 
 Then from your local *caliper-java* directory run:

--- a/src/main/java/org/imsglobal/caliper/config/Config.java
+++ b/src/main/java/org/imsglobal/caliper/config/Config.java
@@ -27,24 +27,22 @@ public class Config {
     private final DataFormat dataFormat;
     private final String dataVersion;
     private final String jsonldExternalCaliperContext;
-    private final String testFixturesBaseDir;
     private final int uuidVersion;
 
     /**
-     * Default data format and version.
+     * Default data format.
      */
     public static final DataFormat DATA_FORMAT = DataFormat.CALIPER_JSONLD;
+
+    /**
+     * Default version
+     */
     public static final String DATA_VERSION = "http://purl.imsglobal.org/ctx/caliper/v1p1";
 
     /**
      * Default IMS Caliper external context document IRI.
      */
     public static final String JSONLD_EXTERNAL_CALIPER_CONTEXT = "http://purl.imsglobal.org/ctx/caliper/v1p1";
-
-    /**
-     * Default test fixtures directory path
-     */
-    public static final String TEST_FIXTURES_BASE_DIR = "../caliper-common-fixtures";
 
     /**
      * Default UUID version to use when minting Event UUIDs.
@@ -60,7 +58,6 @@ public class Config {
         this.dataFormat = (builder.dataFormat != null) ? builder.dataFormat : DATA_FORMAT;
         this.dataVersion = SensorValidator.chkStrValue(builder.dataVersion, DATA_VERSION);
         this.jsonldExternalCaliperContext = SensorValidator.chkStrValue(builder.jsonldExternalCaliperContext, JSONLD_EXTERNAL_CALIPER_CONTEXT);
-        this.testFixturesBaseDir = SensorValidator.chkStrValue(builder.testFixturesBaseDir, TEST_FIXTURES_BASE_DIR);
         this.uuidVersion = SensorValidator.chkIntValue(builder.uuidVersion, UUID_VERSION);
     }
 
@@ -89,14 +86,6 @@ public class Config {
     }
 
     /**
-     * Get the test fixtures base directory path.
-     * @return test fixtures base directory path
-     */
-    public String getTestFixturesBaseDir() {
-        return testFixturesBaseDir;
-    }
-
-    /**
      * Get the UUID version to be used when minting Event UUIDs.
      * @return UUID version
      */
@@ -111,7 +100,6 @@ public class Config {
         private DataFormat dataFormat;
         private String dataVersion;
         private String jsonldExternalCaliperContext;
-        private String testFixturesBaseDir;
         private int uuidVersion = 4;
 
         /**
@@ -145,15 +133,6 @@ public class Config {
          */
         public ConfigBuilder jsonldExternalCaliperContext(final String jsonldExternalCaliperContext) {
             this.jsonldExternalCaliperContext = jsonldExternalCaliperContext;
-            return this;
-        }
-
-        /**
-         * @param testFixturesBaseDir
-         * @return builder
-         */
-        public ConfigBuilder testFixturesBaseDir(final String testFixturesBaseDir) {
-            this.testFixturesBaseDir = testFixturesBaseDir;
             return this;
         }
 

--- a/src/main/java/org/imsglobal/caliper/entities/search/SearchResponse.java
+++ b/src/main/java/org/imsglobal/caliper/entities/search/SearchResponse.java
@@ -41,9 +41,6 @@ public class SearchResponse extends AbstractEntity implements CaliperGeneratable
     @JsonProperty("searchResultsItemCount")
     private final int searchResultsItemCount;
 
-    @JsonProperty("searchResults")
-    private final ImmutableList<CaliperEntity> searchResults;
-
     /**
      * @param builder apply builder object properties to the object.
      */
@@ -53,7 +50,6 @@ public class SearchResponse extends AbstractEntity implements CaliperGeneratable
         this.searchTarget = builder.searchTarget;
         this.query = builder.query;
         this.searchResultsItemCount = builder.searchResultsItemCount;
-        this.searchResults = ImmutableList.copyOf(builder.searchResults);
     }
 
     /**
@@ -89,14 +85,6 @@ public class SearchResponse extends AbstractEntity implements CaliperGeneratable
     }
 
     /**
-     * @return the search results
-     */
-    @Nullable
-    public ImmutableList<CaliperEntity> getSearchResults() {
-        return searchResults;
-    }
-
-    /**
      * Builder class provides a fluid interface for setting object properties.
      * @param <T> builder.
      */
@@ -105,7 +93,6 @@ public class SearchResponse extends AbstractEntity implements CaliperGeneratable
         private CaliperEntity searchTarget;
         private Query query;
         private int searchResultsItemCount;
-        private List<CaliperEntity> searchResults = Lists.newArrayList();
 
         /**
          * Constructor
@@ -147,26 +134,6 @@ public class SearchResponse extends AbstractEntity implements CaliperGeneratable
          */
         public T searchResultsItemCount(int searchResultsItemCount) {
             this.searchResultsItemCount = searchResultsItemCount;
-            return self();
-        }
-
-        /**
-         * @param searchResults
-         * @return builder.
-         */
-        public T searchResults(List<CaliperEntity> searchResults) {
-            if(searchResults != null) {
-                this.searchResults.addAll(searchResults);
-            }
-            return self();
-        }
-
-        /**
-         * @param searchResult
-         * @return builder.
-         */
-        public T searchResult(CaliperEntity searchResult) {
-            this.searchResults.add(searchResult);
             return self();
         }
 

--- a/src/test/java/org/imsglobal/caliper/v1p1/entities/SearchResponseTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p1/entities/SearchResponseTest.java
@@ -50,10 +50,6 @@ public class SearchResponseTest {
     private SoftwareApplication target;
     private Query query;
     private SearchResponse entity;
-    private List<CaliperEntity> results;
-    private Document epub;
-    private Document pdf;
-    private VideoObject video;
 
     private static final String BASE_IRI = "https://example.edu";
     private static final String BASE_CATALOG_IRI = "https://example.edu/catalog";
@@ -73,26 +69,6 @@ public class SearchResponseTest {
             .dateCreated(new DateTime(2018, 11, 15, 10, 5, 0, 0, DateTimeZone.UTC))
             .build();
 
-        pdf = Document.builder()
-            .id(BASE_CATALOG_IRI.concat("/record/01234?query=IMS%20AND%20%28Caliper%20OR%20Analytics%29"))
-            .mediaType("application/pdf")
-            .build();
-
-        video = VideoObject.builder()
-            .id(BASE_CATALOG_IRI.concat("/record/09876?query=IMS%20AND%20%28Caliper%20OR%20Analytics%29"))
-            .mediaType("video/ogg")
-            .build();
-
-        epub = Document.builder()
-            .id(BASE_CATALOG_IRI.concat("/record/05432?query=IMS%20AND%20%28Caliper%20OR%20Analytics%29"))
-            .mediaType("application/epub+zip")
-            .build();
-
-        results = Lists.newArrayList();
-        results.add(pdf);
-        results.add(video);
-        results.add(epub);
-
         entity = SearchResponse.builder()
             .context(JsonldStringContext.create(CaliperJsonldContext.V1P1_SEARCH.value()))
             .id(BASE_IRI.concat("/users/554433/response?query=IMS%20AND%20%28Caliper%20OR%20Analytics%29"))
@@ -100,7 +76,6 @@ public class SearchResponseTest {
             .query(query)
             .searchTarget(target)
             .searchResultsItemCount(3)
-            .searchResults(results)
             .dateCreated(new DateTime(2018, 11, 15, 10, 5, 0, 0, DateTimeZone.UTC))
             .build();
     }

--- a/src/test/java/org/imsglobal/caliper/v1p1/events/SearchEventSearchedTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p1/events/SearchEventSearchedTest.java
@@ -89,33 +89,12 @@ public class SearchEventSearchedTest {
             .dateCreated(new DateTime(2018, 11, 15, 10, 5, 0, 0, DateTimeZone.UTC))
             .build();
 
-        results = Lists.newArrayList();
-        results.add(
-            DigitalResource.builder()
-            .id(BASE_CATALOG_IRI.concat("/record/01234?query=IMS%20AND%20%28Caliper%20OR%20Analytics%29"))
-            .coercedToId(true)
-            .build()
-        );
-        results.add(
-            DigitalResource.builder()
-            .id(BASE_CATALOG_IRI.concat("/record/09876?query=IMS%20AND%20%28Caliper%20OR%20Analytics%29"))
-            .coercedToId(true)
-            .build()
-        );
-        results.add(
-            DigitalResource.builder()
-            .id(BASE_CATALOG_IRI.concat("/record/05432?query=IMS%20AND%20%28Caliper%20OR%20Analytics%29"))
-            .coercedToId(true)
-            .build()
-        );
-
         generated = SearchResponse.builder()
             .id(BASE_IRI.concat("/users/554433/response?query=IMS%20AND%20%28Caliper%20OR%20Analytics%29"))
             .searchProvider(edApp)
             .query(query)
             .searchTarget(catalog)
             .searchResultsItemCount(3)
-            .searchResults(results)
             .build();
 
         group = CourseSection.builder()


### PR DESCRIPTION
This PR updates the README instructions regarding fixtures location (now found at `caliper-spec/fixtures/`), removes `SearchResponse.searchResults` property, and updates relevant tests.