### PR TITLE
Travis: revert to oraclejdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-jdk: oraclejdk8
+jdk: oraclejdk11
 
 install: true
 script: ./mvnw clean install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-jdk: openjdk8
+jdk: oraclejdk8
 
 install: true
 script: ./mvnw clean install


### PR DESCRIPTION
Encountered a Travis build failure due to its inability to download/install `oraclejdk8`.  Switched to `openjdk8` . Encountered another build failure:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.0:testCompile (default-testCompile) on project caliper-java: Compilation failure
[ERROR] /home/travis/build/IMSGlobal/caliper-java/src/test/java/org/imsglobal/caliper/v1p1/events/SearchEventSearchedTest.java:[23,22] package jdk.jfr.events does not exist
```

Reverting to oraclejdk8.