### PR TITLE
Fixing broken test classes for ViewEvent and NavigationEvent

### DIFF
--- a/src/test/java/org/imsglobal/caliper/lti/ResourceLinkClaim.java
+++ b/src/test/java/org/imsglobal/caliper/lti/ResourceLinkClaim.java
@@ -19,7 +19,7 @@
 package org.imsglobal.caliper.lti;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.imsglobal.caliper.v1p1.events.ViewEventViewedFedSessionTest;
+import org.imsglobal.caliper.v1p1.events.ViewEventViewedDocumentFedSessionTest;
 
 public class ResourceLinkClaim {
     @JsonProperty("id")

--- a/src/test/java/org/imsglobal/caliper/v1p1/events/NavigationEventNavigatedToWebPageTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p1/events/NavigationEventNavigatedToWebPageTest.java
@@ -44,7 +44,7 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
 @Category(org.imsglobal.caliper.UnitTest.class)
-public class NavigationEventNavigatedToTest {
+public class NavigationEventNavigatedToWebPageTest {
     private JsonldContext context;
     private String id;
     private Person actor;
@@ -106,7 +106,7 @@ public class NavigationEventNavigatedToTest {
         ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
         String json = mapper.writeValueAsString(event);
 
-        String fixture = jsonFixture("fixtures/v1p1/caliperEventNavigationNavigatedTo.json");
+        String fixture = jsonFixture("fixtures/v1p1/caliperEventNavigationNavigatedToWebPage.json");
         JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
     }
 

--- a/src/test/java/org/imsglobal/caliper/v1p1/events/NavigationEventNavigatedToWebPageThinnedTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p1/events/NavigationEventNavigatedToWebPageThinnedTest.java
@@ -26,12 +26,10 @@ import org.imsglobal.caliper.context.JsonldStringContext;
 import org.imsglobal.caliper.entities.agent.CourseSection;
 import org.imsglobal.caliper.entities.agent.Membership;
 import org.imsglobal.caliper.entities.agent.Person;
-import org.imsglobal.caliper.entities.agent.Role;
 import org.imsglobal.caliper.entities.agent.SoftwareApplication;
-import org.imsglobal.caliper.entities.agent.Status;
-import org.imsglobal.caliper.entities.resource.Document;
+import org.imsglobal.caliper.entities.resource.WebPage;
 import org.imsglobal.caliper.entities.session.Session;
-import org.imsglobal.caliper.events.ViewEvent;
+import org.imsglobal.caliper.events.NavigationEvent;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.After;
@@ -44,74 +42,69 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
 @Category(org.imsglobal.caliper.UnitTest.class)
-public class ViewEventViewedTest {
+public class NavigationEventNavigatedToWebPageThinnedTest {
     private JsonldContext context;
     private String id;
     private Person actor;
-    private Document object;
+    private WebPage object;
     private SoftwareApplication edApp;
     private CourseSection group;
     private Membership membership;
+    private WebPage referrer;
     private Session session;
-    private ViewEvent event;
+    private NavigationEvent event;
 
     private static final String BASE_IRI = "https://example.edu";
+    private static final String SECTION_IRI = BASE_IRI.concat("/terms/201601/courses/7/sections/1");
 
     @Before
     public void setUp() throws Exception {
         context = JsonldStringContext.getDefault();
 
-        id = "urn:uuid:cd088ca7-c044-405c-bb41-0b2a8506f907";
+        id = "urn:uuid:71657137-8e6e-44f8-8499-e1c3df6810d2";
 
-        actor = Person.builder().id(BASE_IRI.concat("/users/554433")).build();
+        actor = Person.builder().id(BASE_IRI.concat("/users/554433")).coercedToId(true).build();
 
-        object = Document.builder()
-            .id(BASE_IRI.concat("/etexts/201.epub"))
-            .name("IMS Caliper Implementation Guide")
-            .version("1.1")
-            .dateCreated(new DateTime(2016, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
-            .datePublished(new DateTime(2016, 10, 1, 6, 0, 0, 0, DateTimeZone.UTC))
+        object = WebPage.builder()
+            .id(SECTION_IRI.concat("/pages/2"))
+            .coercedToId(true)
+            .build();
+
+        referrer = WebPage.builder()
+            .id(SECTION_IRI.concat("/pages/1"))
+            .coercedToId(true)
             .build();
 
         edApp = SoftwareApplication.builder().id(BASE_IRI).coercedToId(true).build();
 
-        group = CourseSection.builder()
-            .id(BASE_IRI.concat("/terms/201601/courses/7/sections/1"))
-            .courseNumber("CPS 435-01")
-            .academicSession("Fall 2016")
-            .build();
+        group = CourseSection.builder().id(SECTION_IRI).coercedToId(true).build();
 
         membership = Membership.builder()
-            .id(BASE_IRI.concat("/terms/201601/courses/7/sections/1/rosters/1"))
-            .member(Person.builder().id(actor.getId()).coercedToId(true).build())
-            .organization(CourseSection.builder().id(group.getId()).coercedToId(true).build())
-            .status(Status.ACTIVE)
-            .role(Role.LEARNER)
-            .dateCreated(new DateTime(2016, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
+            .id(SECTION_IRI.concat("/rosters/1"))
+            .coercedToId(true)
             .build();
 
         session = Session.builder()
             .id(BASE_IRI.concat("/sessions/1f6442a482de72ea6ad134943812bff564a76259"))
-            .startedAtTime(new DateTime(2016, 11, 15, 10, 0, 0, 0, DateTimeZone.UTC))
+            .coercedToId(true)
             .build();
 
         // Build event
-        event = buildEvent(Action.VIEWED);
+        event = buildEvent(Action.NAVIGATED_TO);
     }
 
     @Test
     public void caliperEventSerializesToJSON() throws Exception {
         ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
-
         String json = mapper.writeValueAsString(event);
 
-        String fixture = jsonFixture("fixtures/v1p1/caliperEventViewViewed.json");
+        String fixture = jsonFixture("fixtures/v1p1/caliperEventNavigationNavigatedToWebPageThinned.json");
         JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Test(expected=IllegalArgumentException.class)
-    public void viewEventRejectsNavigatedToAction() {
-        buildEvent(Action.NAVIGATED_TO);
+    public void navigationEventRejectsViewedAction() {
+        buildEvent(Action.VIEWED);
     }
 
     @After
@@ -120,18 +113,19 @@ public class ViewEventViewedTest {
     }
 
     /**
-     * Build View event
+     * Build Navigation event
      * @param action
      * @return event
      */
-    private ViewEvent buildEvent(Action action) {
-        return ViewEvent.builder()
+    private NavigationEvent buildEvent(Action action) {
+        return NavigationEvent.builder()
             .context(context)
             .id(id)
             .actor(actor)
             .action(action)
             .object(object)
             .eventTime(new DateTime(2016, 11, 15, 10, 15, 0, 0, DateTimeZone.UTC))
+            .referrer(referrer)
             .edApp(edApp)
             .group(group)
             .membership(membership)

--- a/src/test/java/org/imsglobal/caliper/v1p1/events/ViewEventViewedDocumentExtendedTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p1/events/ViewEventViewedDocumentExtendedTest.java
@@ -48,7 +48,7 @@ import java.util.Map;
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
 @Category(org.imsglobal.caliper.UnitTest.class)
-public class ViewEventViewedExtendedTest {
+public class ViewEventViewedDocumentExtendedTest {
     private JsonldContext context;
     private String id;
     private Person actor;
@@ -112,7 +112,7 @@ public class ViewEventViewedExtendedTest {
         ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
         String json = mapper.writeValueAsString(event);
 
-        String fixture = jsonFixture("fixtures/v1p1/caliperEventViewViewedExtended.json");
+        String fixture = jsonFixture("fixtures/v1p1/caliperEventViewViewedDocumentExtended.json");
         JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
     }
 

--- a/src/test/java/org/imsglobal/caliper/v1p1/events/ViewEventViewedDocumentFedSessionTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p1/events/ViewEventViewedDocumentFedSessionTest.java
@@ -52,7 +52,7 @@ import java.util.Map;
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
 @Category(org.imsglobal.caliper.UnitTest.class)
-public class ViewEventViewedFedSessionTest {
+public class ViewEventViewedDocumentFedSessionTest {
     private JsonldContext context;
     private String id;
     private Person actor;
@@ -81,7 +81,7 @@ public class ViewEventViewedFedSessionTest {
             .id(BASE_IRI_COM.concat("/lti/reader/202.epub"))
             .mediaType("application/epub+zip")
             .name("Caliper Case Studies")
-            .dateCreated(new DateTime(2016, 8, 1, 9, 0, 0, 0, DateTimeZone.UTC))
+            .dateCreated(new DateTime(2018, 8, 1, 9, 0, 0, 0, DateTimeZone.UTC))
             .build();
 
         edApp = SoftwareApplication.builder().id(BASE_IRI_COM).coercedToId(true).build();
@@ -90,23 +90,23 @@ public class ViewEventViewedFedSessionTest {
         groupExtensions.put("edu_example_course_section_instructor", "https://example.edu/faculty/1234");
 
         group = CourseSection.builder()
-            .id(BASE_IRI_EDU.concat("/terms/201601/courses/7/sections/1"))
+            .id(BASE_IRI_EDU.concat("/terms/201801/courses/7/sections/1"))
             .extensions(groupExtensions)
             .build();
 
         membership = Membership.builder()
-            .id(BASE_IRI_EDU.concat("/terms/201601/courses/7/sections/1/rosters/1"))
+            .id(BASE_IRI_EDU.concat("/terms/201801/courses/7/sections/1/rosters/1"))
             .member(actorToId)
             .organization(CourseSection.builder().id(group.getId()).coercedToId(true).build())
             .status(Status.ACTIVE)
             .role(Role.LEARNER)
-            .dateCreated(new DateTime(2016, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
+            .dateCreated(new DateTime(2018, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
             .build();
 
         session = Session.builder()
             .id(BASE_IRI_COM.concat("/sessions/c25fd3da-87fa-45f5-8875-b682113fa5ee"))
-            .dateCreated(new DateTime(2016, 11, 15, 10, 20, 0, 0, DateTimeZone.UTC))
-            .startedAtTime(new DateTime(2016, 11, 15, 10, 20, 0, 0, DateTimeZone.UTC))
+            .dateCreated(new DateTime(2018, 11, 15, 10, 20, 0, 0, DateTimeZone.UTC))
+            .startedAtTime(new DateTime(2018, 11, 15, 10, 20, 0, 0, DateTimeZone.UTC))
             .build();
 
         Map<String, Object> messageParameters = Maps.newHashMap();
@@ -130,7 +130,7 @@ public class ViewEventViewedFedSessionTest {
         ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
         String json = mapper.writeValueAsString(event);
 
-        String fixture = jsonFixture("fixtures/v1p1/caliperEventViewViewedFedSession.json");
+        String fixture = jsonFixture("fixtures/v1p1/caliperEventViewViewedDocumentFedSession.json");
         JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
     }
 
@@ -157,7 +157,7 @@ public class ViewEventViewedFedSessionTest {
             .actor(actor)
             .action(action)
             .object(object)
-            .eventTime(new DateTime(2016, 11, 15, 10, 20, 0, 0, DateTimeZone.UTC))
+            .eventTime(new DateTime(2018, 11, 15, 10, 20, 0, 0, DateTimeZone.UTC))
             .edApp(edApp)
             .group(group)
             .membership(membership)
@@ -234,8 +234,8 @@ public class ViewEventViewedFedSessionTest {
 
         LisClaim lisClaim = LisClaim.builder()
             .personSourcedId("example.edu:71ee7e42-f6d2-414a-80db-b69ac2defd4")
-            .courseOfferingSourcedId("example.edu:SI182-F16")
-            .courseSectionSourcedId("example.edu:SI182-001-F16")
+            .courseOfferingSourcedId("example.edu:SI182-F18")
+            .courseSectionSourcedId("example.edu:SI182-001-F18")
             .build();
         params.put("https://purl.imsglobal.org/spec/lti/claim/lis", lisClaim);
 


### PR DESCRIPTION
This PR fixes test classes that were broken by changes to fixture file names in IMSGlobal/caliper-spec -- changes which were made as part of [PR #433 to that repo's develop branch](https://github.com/IMSGlobal/caliper-spec/pull/433). Additional fixes were made to one test (`viewEventViewedFedSessionTest.java`) to conform with date changes in the associated fixture from 2016 to 2018.