### PR TITLE
Moving Questionnaire, QuestionnaireItem under entities/resource

### DIFF
--- a/src/main/java/org/imsglobal/caliper/entities/resource/Questionnaire.java
+++ b/src/main/java/org/imsglobal/caliper/entities/resource/Questionnaire.java
@@ -16,14 +16,13 @@
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package org.imsglobal.caliper.entities.survey;
+package org.imsglobal.caliper.entities.resource;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import org.imsglobal.caliper.entities.CaliperCollection;
 import org.imsglobal.caliper.entities.EntityType;
-import org.imsglobal.caliper.entities.resource.AbstractDigitalResource;
 
 import javax.annotation.Nullable;
 import java.util.List;

--- a/src/main/java/org/imsglobal/caliper/entities/resource/QuestionnaireItem.java
+++ b/src/main/java/org/imsglobal/caliper/entities/resource/QuestionnaireItem.java
@@ -16,14 +16,13 @@
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package org.imsglobal.caliper.entities.survey;
+package org.imsglobal.caliper.entities.resource;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import org.imsglobal.caliper.entities.EntityType;
 import org.imsglobal.caliper.entities.question.Question;
-import org.imsglobal.caliper.entities.resource.AbstractDigitalResource;
 
 import javax.annotation.Nullable;
 import java.util.List;

--- a/src/main/java/org/imsglobal/caliper/entities/survey/Survey.java
+++ b/src/main/java/org/imsglobal/caliper/entities/survey/Survey.java
@@ -25,7 +25,7 @@ import com.google.common.collect.Lists;
 import org.imsglobal.caliper.entities.AbstractEntity;
 import org.imsglobal.caliper.entities.EntityType;
 import org.imsglobal.caliper.entities.CaliperCollection;
-import org.imsglobal.caliper.entities.survey.Questionnaire;
+import org.imsglobal.caliper.entities.resource.Questionnaire;
 
 import javax.annotation.Nullable;
 import java.util.List;


### PR DESCRIPTION
This PR moves the `Questionnaire` and `QuestionnaireItem` classes from entities/survey to the entities/resource directory to bring the structure in line with caliper-js.