### PR TITLE
Allow for 0 scores to be included as its pretty common for a scoreGiv…

### DIFF
--- a/src/main/java/org/imsglobal/caliper/entities/outcome/Score.java
+++ b/src/main/java/org/imsglobal/caliper/entities/outcome/Score.java
@@ -70,7 +70,7 @@ public class Score extends AbstractEntity implements CaliperGeneratable {
      */
     @Nullable
     // @JsonSerialize(using=DoubleSerializer.class)
-    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public double getMaxScore() {
         return maxScore;
     }
@@ -80,7 +80,7 @@ public class Score extends AbstractEntity implements CaliperGeneratable {
      */
     @Nullable
     // @JsonSerialize(using=DoubleSerializer.class)
-    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public double getScoreGiven() {
         return scoreGiven;
     }


### PR DESCRIPTION
…en on a test to be 0.
1. Updates Json Include to be JsonInclude.Include.NON_EMPTY instead JsonInclude.Include.NON_DEFAULT so that we allow zero scores to be included.
2. NON_EMPTY also seems to be a reasonable strategy for maxScore