### PR TITLE
Implementing Session.client and SystemIdentifier; expanding test coverage

### DIFF
--- a/src/main/java/org/imsglobal/caliper/Namespace.java
+++ b/src/main/java/org/imsglobal/caliper/Namespace.java
@@ -16,35 +16,12 @@
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package org.imsglobal.caliper.events;
+package org.imsglobal.caliper;
 
 import com.fasterxml.jackson.annotation.JsonValue;
-import org.imsglobal.caliper.Namespace;
 
-public enum EventType implements CaliperEventType {
-    ANNOTATION("AnnotationEvent"),
-    ASSESSMENT("AssessmentEvent"),
-    ASSESSMENT_ITEM("AssessmentItemEvent"),
-    ASSIGNABLE("AssignableEvent"),
-    EVENT("Event"),
-    FEEDBACK("FeedbackEvent"),
-    FORUM("ForumEvent"),
-    MEDIA("MediaEvent"),
-    MESSAGE("MessageEvent"),
-    NAVIGATION("NavigationEvent"),
-    GRADE("GradeEvent"),
-    QUESTIONNAIRE("QuestionnaireEvent"),
-    QUESTIONNAIRE_ITEM("QuestionnaireItemEvent"),
-    READING("ReadingEvent"),
-    RESOURCE_MANAGEMENT("ResourceManagementEvent"),
-    SEARCH("SearchEvent"),
-    SESSION("SessionEvent"),
-    SURVEY("SurveyEvent"),
-    SURVEY_INVITATION("SurveyInvitationEvent"),
-    THREAD("ThreadEvent"),
-    TOOL_LAUNCH("ToolLaunchEvent"),
-    TOOL_USE("ToolUseEvent"),
-    VIEW("ViewEvent");
+public enum Namespace {
+    CALIPER("http://purl.imsglobal.org/caliper/");
 
     private final String value;
 
@@ -52,20 +29,15 @@ public enum EventType implements CaliperEventType {
      * Private constructor
      * @param value
      */
-    private EventType(final String value) {
+    private Namespace(final String value) {
         this.value = value;
     }
 
     /**
-     * @return term string for Event type
+     * @return IRI string for namespace
      */
     @JsonValue
     public String value() {
         return value;
     }
-
-    /**
-     * @return full IRI for the Caliper Event type
-     */
-    public String expandToIRI() {return Namespace.CALIPER.value().concat(this.value());}
 }

--- a/src/main/java/org/imsglobal/caliper/entities/AbstractEntity.java
+++ b/src/main/java/org/imsglobal/caliper/entities/AbstractEntity.java
@@ -20,12 +20,16 @@ package org.imsglobal.caliper.entities;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import org.imsglobal.caliper.context.JsonldContext;
+import org.imsglobal.caliper.identifiers.SystemIdentifier;
 import org.imsglobal.caliper.validators.EntityValidator;
 import org.joda.time.DateTime;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -58,6 +62,9 @@ public abstract class AbstractEntity implements CaliperEntity, CaliperCoercible 
     @JsonProperty("dateModified")
     private final DateTime dateModified;
 
+    @JsonProperty("otherIdentifiers")
+    private final ImmutableList<SystemIdentifier> otherIdentifiers;
+
     @JsonProperty("extensions")
     private final Map<String, Object> extensions;
 
@@ -76,6 +83,7 @@ public abstract class AbstractEntity implements CaliperEntity, CaliperCoercible 
         this.description = builder.description;
         this.dateCreated = builder.dateCreated;
         this.dateModified = builder.dateModified;
+        this.otherIdentifiers = ImmutableList.copyOf(builder.otherIdentifiers);
         this.extensions = builder.extensions;
     }
 
@@ -144,6 +152,14 @@ public abstract class AbstractEntity implements CaliperEntity, CaliperCoercible 
     }
 
     /**
+     * @return the array of SystemIdentifiers
+     */
+    @Nullable
+    public ImmutableList<SystemIdentifier> getOtherIdentifiers() {
+        return otherIdentifiers;
+    }
+
+    /**
      * @return custom extensions object.
      */
     @Nullable
@@ -164,6 +180,7 @@ public abstract class AbstractEntity implements CaliperEntity, CaliperCoercible 
         private String description;
         private DateTime dateCreated;
         private DateTime dateModified;
+        private List<SystemIdentifier> otherIdentifiers = Lists.newArrayList();
         private Map<String, Object> extensions;
 
         /**
@@ -245,6 +262,17 @@ public abstract class AbstractEntity implements CaliperEntity, CaliperCoercible 
          */
         public T dateModified(DateTime dateModified) {
             this.dateModified = dateModified;
+            return self();
+        }
+
+        /**
+         * @param otherIdentifiers
+         * @return builder.
+         */
+        public T otherIdentifiers(List<SystemIdentifier> otherIdentifiers) {
+            if(otherIdentifiers != null) {
+                this.otherIdentifiers.addAll(otherIdentifiers);
+            }
             return self();
         }
 

--- a/src/main/java/org/imsglobal/caliper/entities/AbstractEntity.java
+++ b/src/main/java/org/imsglobal/caliper/entities/AbstractEntity.java
@@ -277,6 +277,15 @@ public abstract class AbstractEntity implements CaliperEntity, CaliperCoercible 
         }
 
         /**
+         * @param otherIdentifier
+         * @return builder.
+         */
+        public T otherIdentifier(SystemIdentifier otherIdentifier) {
+            this.otherIdentifiers.add(otherIdentifier);
+            return self();
+        }
+
+        /**
          * @param extensions
          * @return builder.
          */

--- a/src/main/java/org/imsglobal/caliper/entities/EntityType.java
+++ b/src/main/java/org/imsglobal/caliper/entities/EntityType.java
@@ -19,6 +19,7 @@
 package org.imsglobal.caliper.entities;
 
 import com.fasterxml.jackson.annotation.JsonValue;
+import org.imsglobal.caliper.Namespace;
 
 public enum EntityType implements CaliperEntityType {
     AGENT("Agent"),
@@ -108,10 +109,15 @@ public enum EntityType implements CaliperEntityType {
     }
 
     /**
-     * @return URI string
+     * @return term string for Entity type
      */
     @JsonValue
     public String value() {
         return value;
     }
+
+    /**
+     * @return full IRI for the Caliper Entity type
+     */
+    public String expandToIRI() {return Namespace.CALIPER.value().concat(this.value());}
 }

--- a/src/main/java/org/imsglobal/caliper/entities/agent/SoftwareApplication.java
+++ b/src/main/java/org/imsglobal/caliper/entities/agent/SoftwareApplication.java
@@ -27,15 +27,27 @@ import javax.annotation.Nullable;
 
 public class SoftwareApplication extends AbstractEntity implements CaliperAgent, CaliperReferable {
 
+    @JsonProperty("host")
+    private final String host;
+
+    @JsonProperty("ipAddress")
+    private final String ipAddress;
+
+    @JsonProperty("userAgent")
+    private final String userAgent;
+
     @JsonProperty("version")
     private final String version;
 
     /**
      * @param builder apply builder object properties to the object.
      */
-    protected SoftwareApplication(Builder<?> builder) {
+    private SoftwareApplication(Builder<?> builder) {
         super(builder);
         this.version = builder.version;
+        this.host = builder.host;
+        this.ipAddress = builder.ipAddress;
+        this.userAgent = builder.userAgent;
     }
 
     /**
@@ -47,11 +59,38 @@ public class SoftwareApplication extends AbstractEntity implements CaliperAgent,
     }
 
     /**
+     * @return the host
+     */
+    @Nullable
+    public String getHost() {
+        return host;
+    }
+
+    /**
+     * @return the ipAddress
+     */
+    @Nullable
+    public String getIpAddress() {
+        return ipAddress;
+    }
+
+    /**
+     * @return the userAgent
+     */
+    @Nullable
+    public String getUserAgent() {
+        return userAgent;
+    }
+
+    /**
      * Builder class provides a fluid interface for setting object properties.
      * @param <T> builder.
      */
     public static abstract class Builder<T extends Builder<T>> extends AbstractEntity.Builder<T> {
         private String version;
+        private String host;
+        private String ipAddress;
+        private String userAgent;
 
         /**
          * Constructor
@@ -66,6 +105,33 @@ public class SoftwareApplication extends AbstractEntity implements CaliperAgent,
          */
         public T version(String version) {
             this.version = version;
+            return self();
+        }
+
+        /**
+         * @param host
+         * @return builder.
+         */
+        public T host(String host) {
+            this.host = host;
+            return self();
+        }
+
+        /**
+         * @param ipAddress
+         * @return builder.
+         */
+        public T ipAddress(String ipAddress) {
+            this.ipAddress = ipAddress;
+            return self();
+        }
+
+        /**
+         * @param userAgent
+         * @return builder.
+         */
+        public T userAgent(String userAgent) {
+            this.userAgent = userAgent;
             return self();
         }
 

--- a/src/main/java/org/imsglobal/caliper/entities/session/AbstractSession.java
+++ b/src/main/java/org/imsglobal/caliper/entities/session/AbstractSession.java
@@ -24,6 +24,7 @@ import org.imsglobal.caliper.entities.AbstractEntity;
 import org.imsglobal.caliper.entities.EntityType;
 import org.imsglobal.caliper.entities.TimePeriod;
 import org.imsglobal.caliper.entities.agent.CaliperAgent;
+import org.imsglobal.caliper.entities.agent.SoftwareApplication;
 import org.imsglobal.caliper.validators.EntityValidator;
 import org.joda.time.DateTime;
 
@@ -38,6 +39,9 @@ public abstract class AbstractSession extends AbstractEntity implements CaliperS
     @JsonProperty("user")
     private final CaliperAgent user;
 
+    @JsonProperty("client")
+    private SoftwareApplication client;
+
     @JsonIgnore
     private TimePeriod timePeriod = new TimePeriod();
 
@@ -51,6 +55,7 @@ public abstract class AbstractSession extends AbstractEntity implements CaliperS
         EntityValidator.checkDuration(builder.timePeriod.getDuration());
 
         this.user = builder.user;
+        this.client = builder.client;
         this.timePeriod.setStartedAtTime(builder.timePeriod.getStartedAtTime());
         this.timePeriod.setEndedAtTime(builder.timePeriod.getEndedAtTime());
         this.timePeriod.setDuration(builder.timePeriod.getDuration());
@@ -62,6 +67,14 @@ public abstract class AbstractSession extends AbstractEntity implements CaliperS
     @Nullable
     public CaliperAgent getUser() {
         return user;
+    }
+
+    /**
+     * @return client
+     */
+    @Nullable
+    public SoftwareApplication getClient() {
+        return client;
     }
 
     /**
@@ -94,6 +107,7 @@ public abstract class AbstractSession extends AbstractEntity implements CaliperS
      */
     public static abstract class Builder<T extends Builder<T>> extends AbstractEntity.Builder<T>  {
         private CaliperAgent user;
+        private SoftwareApplication client;
         private TimePeriod timePeriod = new TimePeriod();
 
         /**
@@ -109,6 +123,15 @@ public abstract class AbstractSession extends AbstractEntity implements CaliperS
          */
         public T user(CaliperAgent user) {
             this.user = user;
+            return self();
+        }
+
+        /**
+         * @param client
+         * @return builder.
+         */
+        public T client(SoftwareApplication client) {
+            this.client = client;
             return self();
         }
 

--- a/src/main/java/org/imsglobal/caliper/identifiers/SystemIdentifier.java
+++ b/src/main/java/org/imsglobal/caliper/identifiers/SystemIdentifier.java
@@ -1,0 +1,165 @@
+/**
+ * This file is part of IMS Caliper Analytics™ and is licensed to
+ * IMS Global Learning Consortium, Inc. (http://www.imsglobal.org)
+ * under one or more contributor license agreements.  See the NOTICE
+ * file distributed with this work for additional information.
+ *
+ * IMS Caliper is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * IMS Caliper is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.imsglobal.caliper.identifiers;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.imsglobal.caliper.entities.agent.SoftwareApplication;
+
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class SystemIdentifier {
+
+    @JsonProperty("type")
+    private final String type;
+
+    @JsonProperty("identifierType")
+    private final SystemIdentifierType identifierType;
+
+    @JsonProperty("identifier")
+    private final String identifier;
+
+    @JsonProperty("source")
+    private final SoftwareApplication source;
+
+    @JsonProperty("extensions")
+    private final Map<String, Object> extensions;
+
+    /**
+     * @param builder apply builder object properties to the object.
+     */
+    private SystemIdentifier(Builder<?> builder) {
+        this.type = builder.type;
+        this.identifierType = builder.identifierType;
+        this.identifier = builder.identifier;
+        this.source = builder.source;
+        this.extensions = builder.extensions;
+    }
+
+    /**
+     * @return the type
+     */
+    @Nonnull
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * @return the identifierType
+     */
+    @Nonnull
+    public SystemIdentifierType getIdentifierType() {
+        return identifierType;
+    }
+
+    /**
+     * @return the identifier
+     */
+    @Nonnull
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    /**
+     * @return the source
+     */
+    @Nullable
+    public SoftwareApplication getSource() {
+        return source;
+    }
+
+    /**
+     * @return the extensions
+     */
+    @Nullable
+    public Map<String, Object> getExtensions() { return extensions; }
+
+    /**
+     * Builder class provides a fluid interface for setting object properties.
+     * @param <T> builder.
+     */
+    public static abstract class Builder<T extends Builder<T>> {
+        private String type;
+        private SystemIdentifierType identifierType;
+        private String identifier;
+        private SoftwareApplication source;
+        private Map<String, Object> extensions;
+
+        /**
+         * Constructor
+         */
+        public Builder() {
+            type("SystemIdentifier");
+        }
+
+        protected abstract T self();
+
+        public T type(String type) {
+            this.type = type;
+            return self();
+        }
+
+        public T identifierType(SystemIdentifierType identifierType) {
+            this.identifierType = identifierType;
+            return self();
+        }
+
+        public T identifier(String identifier) {
+            this.identifier = identifier;
+            return self();
+        }
+
+        public T source(SoftwareApplication source) {
+            this.source = source;
+            return self();
+        }
+
+        public T extensions(Map<String, Object> extensions) {
+            this.extensions = extensions;
+            return self();
+        }
+
+        /**
+         * Client invokes build method in order to create an immutable object.
+         * @return a new instance of SystemIdentifier.
+         */
+        public SystemIdentifier build() {
+            return new SystemIdentifier(this);
+        }
+    }
+
+    /**
+     *
+     */
+    private static class Builder2 extends Builder<Builder2> {
+        @Override
+        protected Builder2 self() {
+            return this;
+        }
+    }
+
+    /**
+     * Static factory method.
+     * @return a new instance of the builder.
+     */
+    public static Builder<?> builder() {
+        return new Builder2();
+    }
+}

--- a/src/main/java/org/imsglobal/caliper/identifiers/SystemIdentifierType.java
+++ b/src/main/java/org/imsglobal/caliper/identifiers/SystemIdentifierType.java
@@ -1,0 +1,54 @@
+/**
+ * This file is part of IMS Caliper Analytics™ and is licensed to
+ * IMS Global Learning Consortium, Inc. (http://www.imsglobal.org)
+ * under one or more contributor license agreements.  See the NOTICE
+ * file distributed with this work for additional information.
+ *
+ * IMS Caliper is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * IMS Caliper is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.imsglobal.caliper.identifiers;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum SystemIdentifierType {
+    ACCOUNT_USER_NAME("AccountUserName"),
+    EMAIL_ADDRESS("EmailAddress"),
+    LIS_SOURCED_ID("LisSourcedId"),
+    LTI_CONTEXT_ID("LtiContextId"),
+    LTI_DEPLOYMENT_ID("LtiDeploymentId"),
+    LTI_PLATFORM_ID("LtiPlatformId"),
+    LTI_TOOL_ID("LtiToolId"),
+    LTI_USER_ID("LtiUserId"),
+    ONE_ROSTER_SOURCED_ID("OneRosterSourcedId"),
+    OTHER("Other"),
+    SIS_SOURCED_ID("SisSourcedId"),
+    SYSTEM_ID("SystemId");
+
+    private final String value;
+
+    /**
+     * Private constructor
+     * @param value
+     */
+    private SystemIdentifierType(final String value) {
+        this.value = value;
+    }
+
+    /**
+     * @return URI string
+     */
+    @JsonValue
+    public String value() {
+        return value;
+    }
+}

--- a/src/test/java/org/imsglobal/caliper/v1p2/entities/CourseOfferingAnonymousTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/entities/CourseOfferingAnonymousTest.java
@@ -1,0 +1,65 @@
+/**
+ * This file is part of IMS Caliper Analytics™ and is licensed to
+ * IMS Global Learning Consortium, Inc. (http://www.imsglobal.org)
+ * under one or more contributor license agreements.  See the NOTICE
+ * file distributed with this work for additional information.
+ *
+ * IMS Caliper is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * IMS Caliper is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.imsglobal.caliper.v1p2.entities;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.imsglobal.caliper.TestUtils;
+import org.imsglobal.caliper.context.CaliperJsonldContextIRI;
+import org.imsglobal.caliper.context.JsonldStringContext;
+import org.imsglobal.caliper.entities.agent.CourseOffering;
+import org.imsglobal.caliper.entities.EntityType;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
+
+@Category(org.imsglobal.caliper.UnitTest.class)
+public class CourseOfferingAnonymousTest {
+    private CourseOffering entity;
+
+    private static final String BASE_IRI = "https://example.edu";
+    private static final String BASE_TERM_IRI = "http://purl.imsglobal.org/caliper/";
+
+    @Before
+    public void setUp() throws Exception {
+
+        entity = CourseOffering.builder()
+            .context(JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value()))
+            .id(BASE_TERM_IRI.concat(EntityType.COURSE_OFFERING.value()))
+            .build();
+    }
+
+    @Test
+    public void caliperEntitySerializesToJSON() throws Exception {
+        ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
+        String json = mapper.writeValueAsString(entity);
+
+        String fixture = jsonFixture("fixtures/v1p2/caliperEntityCourseOfferingAnonymous.json");
+        JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
+    }
+
+    @After
+    public void teardown() {
+        entity = null;
+    }
+}

--- a/src/test/java/org/imsglobal/caliper/v1p2/entities/CourseOfferingAnonymousTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/entities/CourseOfferingAnonymousTest.java
@@ -38,14 +38,13 @@ public class CourseOfferingAnonymousTest {
     private CourseOffering entity;
 
     private static final String BASE_IRI = "https://example.edu";
-    private static final String BASE_TERM_IRI = "http://purl.imsglobal.org/caliper/";
 
     @Before
     public void setUp() throws Exception {
 
         entity = CourseOffering.builder()
             .context(JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value()))
-            .id(BASE_TERM_IRI.concat(EntityType.COURSE_OFFERING.value()))
+            .id(EntityType.COURSE_OFFERING.expandToIRI())
             .build();
     }
 

--- a/src/test/java/org/imsglobal/caliper/v1p2/entities/CourseOfferingTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/entities/CourseOfferingTest.java
@@ -53,16 +53,13 @@ public class CourseOfferingTest {
             .identifierType(SystemIdentifierType.LIS_SOURCED_ID)
             .build();
 
-        List<SystemIdentifier> otherIdentifiers = Lists.newArrayList();
-        otherIdentifiers.add(systemIdentifier);
-
         entity = CourseOffering.builder()
             .context(JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value()))
             .id(BASE_IRI.concat("/terms/201601/courses/7"))
             .courseNumber("CPS 435")
             .academicSession("Fall 2016")
             .name("CPS 435 Learning Analytics")
-            .otherIdentifiers(otherIdentifiers)
+            .otherIdentifier(systemIdentifier)
             .dateCreated(new DateTime(2016, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
             .dateModified(new DateTime(2016, 9, 2, 11, 30, 0, 0, DateTimeZone.UTC))
             .build();

--- a/src/test/java/org/imsglobal/caliper/v1p2/entities/CourseOfferingTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/entities/CourseOfferingTest.java
@@ -1,0 +1,84 @@
+/**
+ * This file is part of IMS Caliper Analytics™ and is licensed to
+ * IMS Global Learning Consortium, Inc. (http://www.imsglobal.org)
+ * under one or more contributor license agreements.  See the NOTICE
+ * file distributed with this work for additional information.
+ *
+ * IMS Caliper is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * IMS Caliper is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.imsglobal.caliper.v1p2.entities;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
+import org.imsglobal.caliper.TestUtils;
+import org.imsglobal.caliper.context.CaliperJsonldContextIRI;
+import org.imsglobal.caliper.context.JsonldStringContext;
+import org.imsglobal.caliper.entities.agent.CourseOffering;
+import org.imsglobal.caliper.identifiers.SystemIdentifier;
+import org.imsglobal.caliper.identifiers.SystemIdentifierType;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import java.util.List;
+
+import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
+
+@Category(org.imsglobal.caliper.UnitTest.class)
+public class CourseOfferingTest {
+    private CourseOffering entity;
+
+    private static final String BASE_IRI = "https://example.edu";
+
+    @Before
+    public void setUp() throws Exception {
+
+        SystemIdentifier systemIdentifier = SystemIdentifier.builder()
+            .identifier("example.edu:SI182-F16")
+            .identifierType(SystemIdentifierType.LIS_SOURCED_ID)
+            .build();
+
+        List<SystemIdentifier> otherIdentifiers = Lists.newArrayList();
+        otherIdentifiers.add(systemIdentifier);
+
+        entity = CourseOffering.builder()
+            .context(JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value()))
+            .id(BASE_IRI.concat("/terms/201601/courses/7"))
+            .courseNumber("CPS 435")
+            .academicSession("Fall 2016")
+            .name("CPS 435 Learning Analytics")
+            .otherIdentifiers(otherIdentifiers)
+            .dateCreated(new DateTime(2016, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
+            .dateModified(new DateTime(2016, 9, 2, 11, 30, 0, 0, DateTimeZone.UTC))
+            .build();
+    }
+
+    @Test
+    public void caliperEntitySerializesToJSON() throws Exception {
+        ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
+        String json = mapper.writeValueAsString(entity);
+
+        String fixture = jsonFixture("fixtures/v1p2/caliperEntityCourseOffering.json");
+        JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
+    }
+
+    @After
+    public void teardown() {
+        entity = null;
+    }
+}

--- a/src/test/java/org/imsglobal/caliper/v1p2/entities/PersonAnonymousTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/entities/PersonAnonymousTest.java
@@ -37,16 +37,12 @@ import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 public class PersonAnonymousTest {
     private Person entity;
 
-    private static final String BASE_IRI = "https://example.edu";
-    private static final String BASE_TERM_IRI = "http://purl.imsglobal.org/caliper/";
-
-
     @Before
     public void setUp() throws Exception {
 
         entity = Person.builder()
             .context(JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value()))
-            .id(BASE_TERM_IRI.concat(EntityType.PERSON.value()))
+            .id(EntityType.PERSON.expandToIRI())
             .build();
     }
 

--- a/src/test/java/org/imsglobal/caliper/v1p2/entities/PersonAnonymousTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/entities/PersonAnonymousTest.java
@@ -1,0 +1,66 @@
+/**
+ * This file is part of IMS Caliper Analytics™ and is licensed to
+ * IMS Global Learning Consortium, Inc. (http://www.imsglobal.org)
+ * under one or more contributor license agreements.  See the NOTICE
+ * file distributed with this work for additional information.
+ *
+ * IMS Caliper is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * IMS Caliper is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.imsglobal.caliper.v1p2.entities;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.imsglobal.caliper.TestUtils;
+import org.imsglobal.caliper.context.CaliperJsonldContextIRI;
+import org.imsglobal.caliper.context.JsonldStringContext;
+import org.imsglobal.caliper.entities.agent.Person;
+import org.imsglobal.caliper.entities.EntityType;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
+
+@Category(org.imsglobal.caliper.UnitTest.class)
+public class PersonAnonymousTest {
+    private Person entity;
+
+    private static final String BASE_IRI = "https://example.edu";
+    private static final String BASE_TERM_IRI = "http://purl.imsglobal.org/caliper/";
+
+
+    @Before
+    public void setUp() throws Exception {
+
+        entity = Person.builder()
+            .context(JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value()))
+            .id(BASE_TERM_IRI.concat(EntityType.PERSON.value()))
+            .build();
+    }
+
+    @Test
+    public void caliperEntitySerializesToJSON() throws Exception {
+        ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
+        String json = mapper.writeValueAsString(entity);
+
+        String fixture = jsonFixture("fixtures/v1p2/caliperEntityPersonAnonymous.json");
+        JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
+    }
+
+    @After
+    public void teardown() {
+        entity = null;
+    }
+}

--- a/src/test/java/org/imsglobal/caliper/v1p2/entities/PersonTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/entities/PersonTest.java
@@ -1,0 +1,110 @@
+/**
+ * This file is part of IMS Caliper Analytics™ and is licensed to
+ * IMS Global Learning Consortium, Inc. (http://www.imsglobal.org)
+ * under one or more contributor license agreements.  See the NOTICE
+ * file distributed with this work for additional information.
+ *
+ * IMS Caliper is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * IMS Caliper is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.imsglobal.caliper.v1p2.entities;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import org.imsglobal.caliper.TestUtils;
+import org.imsglobal.caliper.context.CaliperJsonldContextIRI;
+import org.imsglobal.caliper.context.JsonldStringContext;
+import org.imsglobal.caliper.entities.agent.Person;
+import org.imsglobal.caliper.entities.agent.SoftwareApplication;
+import org.imsglobal.caliper.identifiers.SystemIdentifier;
+import org.imsglobal.caliper.identifiers.SystemIdentifierType;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
+
+@Category(org.imsglobal.caliper.UnitTest.class)
+public class PersonTest {
+    private Person entity;
+
+    private static final String BASE_IRI = "https://example.edu";
+    private static final String USER_IRI = BASE_IRI.concat("/users/554433");
+
+    @Before
+    public void setUp() throws Exception {
+
+        SystemIdentifier identifierOne = SystemIdentifier.builder()
+            .identifier("example.edu:71ee7e42-f6d2-414a-80db-b69ac2defd4")
+            .identifierType(SystemIdentifierType.LIS_SOURCED_ID)
+            .build();
+
+        SystemIdentifier identifierTwo = SystemIdentifier.builder()
+            .identifier(USER_IRI)
+            .identifierType(SystemIdentifierType.LTI_USER_ID)
+            .source(SoftwareApplication.builder().id(BASE_IRI).build())
+            .build();
+
+        SystemIdentifier identifierThree = SystemIdentifier.builder()
+            .identifier("jane@example.edu")
+            .identifierType(SystemIdentifierType.EMAIL_ADDRESS)
+            .source(SoftwareApplication.builder().id(BASE_IRI).coercedToId(true).build())
+            .build();
+
+        Map<String, Object> extensionsForFour = Maps.newHashMap();
+        extensionsForFour.put("com.examplePlatformVendor.identifier_type", "UserIdentifier");
+
+        SystemIdentifier identifierFour = SystemIdentifier.builder()
+            .identifier("4567")
+            .identifierType(SystemIdentifierType.SYSTEM_ID)
+            .extensions(extensionsForFour)
+            .build();
+
+        SystemIdentifier[] systemIdentifierArray = { identifierOne,  identifierTwo, identifierThree, identifierFour };
+
+        List<SystemIdentifier> otherIdentifiers = Lists.newArrayList();
+        otherIdentifiers.addAll(Arrays.asList(systemIdentifierArray));
+
+        entity = Person.builder()
+            .context(JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value()))
+            .id(BASE_IRI.concat("/users/554433"))
+            .otherIdentifiers(otherIdentifiers)
+            .dateCreated(new DateTime(2016, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
+            .dateModified(new DateTime(2016, 9, 2, 11, 30, 0, 0, DateTimeZone.UTC))
+            .build();
+    }
+
+    @Test
+    public void caliperEntitySerializesToJSON() throws Exception {
+        ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
+        String json = mapper.writeValueAsString(entity);
+
+        String fixture = jsonFixture("fixtures/v1p2/caliperEntityPerson.json");
+        JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
+    }
+
+    @After
+    public void teardown() {
+        entity = null;
+    }
+}
+

--- a/src/test/java/org/imsglobal/caliper/v1p2/entities/SessionClientTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/entities/SessionClientTest.java
@@ -1,0 +1,80 @@
+/**
+ * This file is part of IMS Caliper Analytics™ and is licensed to
+ * IMS Global Learning Consortium, Inc. (http://www.imsglobal.org)
+ * under one or more contributor license agreements.  See the NOTICE
+ * file distributed with this work for additional information.
+ *
+ * IMS Caliper is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * IMS Caliper is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.imsglobal.caliper.v1p2.entities;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.imsglobal.caliper.TestUtils;
+import org.imsglobal.caliper.context.CaliperJsonldContextIRI;
+import org.imsglobal.caliper.context.JsonldStringContext;
+import org.imsglobal.caliper.entities.agent.CaliperAgent;
+import org.imsglobal.caliper.entities.agent.Person;
+import org.imsglobal.caliper.entities.agent.SoftwareApplication;
+import org.imsglobal.caliper.entities.session.Session;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
+
+@Category(org.imsglobal.caliper.UnitTest.class)
+public class SessionClientTest {
+    private Session entity;
+
+    private static final String BASE_IRI = "https://example.edu";
+
+    @Before
+    public void setUp() throws Exception {
+
+        CaliperAgent user = Person.builder().id(BASE_IRI.concat("/users/554433")).build();
+
+        SoftwareApplication client = SoftwareApplication.builder()
+            .id("urn:uuid:d71016dc-ed2f-46f9-ac2c-b93f15f38fdc")
+            .host(BASE_IRI)
+            .userAgent("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36")
+            .ipAddress("2001:0db8:85a3:0000:0000:8a2e:0370:7334")
+            .build();
+
+        entity = Session.builder()
+            .context(JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value()))
+            .id(BASE_IRI.concat("/sessions/1f6442a482de72ea6ad134943812bff564a76259"))
+            .user(user)
+            .client(client)
+            .startedAtTime(new DateTime(2018, 9, 15, 10, 0, 0, 0, DateTimeZone.UTC))
+            .build();
+    }
+
+    @Test
+    public void caliperEntitySerializesToJSON() throws Exception {
+        ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
+        String json = mapper.writeValueAsString(entity);
+
+        String fixture = jsonFixture("fixtures/v1p2/caliperEntitySessionClient.json");
+        JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
+    }
+
+    @After
+    public void teardown() {
+        entity = null;
+    }
+}

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/ToolUseEventUsedAnonymousTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/ToolUseEventUsedAnonymousTest.java
@@ -1,0 +1,128 @@
+/**
+ * This file is part of IMS Caliper Analytics™ and is licensed to
+ * IMS Global Learning Consortium, Inc. (http://www.imsglobal.org)
+ * under one or more contributor license agreements.  See the NOTICE
+ * file distributed with this work for additional information.
+ *
+ * IMS Caliper is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * IMS Caliper is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.imsglobal.caliper.v1p2.events;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.imsglobal.caliper.TestUtils;
+import org.imsglobal.caliper.actions.Action;
+import org.imsglobal.caliper.actions.CaliperAction;
+import org.imsglobal.caliper.context.CaliperJsonldContextIRI;
+import org.imsglobal.caliper.context.JsonldContext;
+import org.imsglobal.caliper.context.JsonldStringContext;
+import org.imsglobal.caliper.entities.agent.CourseSection;
+import org.imsglobal.caliper.entities.agent.Membership;
+import org.imsglobal.caliper.entities.agent.Person;
+import org.imsglobal.caliper.entities.agent.Role;
+import org.imsglobal.caliper.entities.agent.SoftwareApplication;
+import org.imsglobal.caliper.entities.agent.Status;
+import org.imsglobal.caliper.entities.EntityType;
+import org.imsglobal.caliper.events.ToolUseEvent;
+import org.imsglobal.caliper.profiles.CaliperProfile;
+import org.imsglobal.caliper.profiles.Profile;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
+
+@Category(org.imsglobal.caliper.UnitTest.class)
+public class ToolUseEventUsedAnonymousTest {
+    private JsonldContext context;
+    private String id;
+    private Person actor;
+    private SoftwareApplication object, edApp;
+    private CourseSection group;
+    private Membership membership;
+    private ToolUseEvent event;
+
+    private static final String BASE_IRI = "https://example.edu";
+    private static final String BASE_TERM_IRI = "http://purl.imsglobal.org/caliper/";
+
+    @Before
+    public void setUp() throws Exception {
+
+        CourseSection anonymousSection = CourseSection.builder()
+            .id(BASE_TERM_IRI.concat(EntityType.COURSE_SECTION.value()))
+            .build();
+
+        Person anonymousPerson = Person.builder().id(BASE_TERM_IRI.concat(EntityType.PERSON.value())).build();
+
+        context = JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value());
+
+        id = "urn:uuid:7c0fc54b-cf2a-426f-9203-b2c97fb77bfd";
+
+        actor = anonymousPerson;
+
+        object = SoftwareApplication.builder().id(BASE_IRI).build();
+
+        edApp = SoftwareApplication.builder().id(BASE_IRI).coercedToId(true).build();
+
+        group = anonymousSection;
+
+        membership = Membership.builder()
+            .id(BASE_TERM_IRI.concat(EntityType.MEMBERSHIP.value()))
+            .member(anonymousPerson)
+            .organization(anonymousSection)
+            .status(Status.ACTIVE)
+            .role(Role.LEARNER)
+            .build();
+
+        // Build event
+        event = buildEvent(Profile.TOOL_USE, Action.USED);
+    }
+
+    @Test
+    public void caliperEventSerializesToJSON() throws Exception {
+        ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
+        String json = mapper.writeValueAsString(event);
+
+        String fixture = jsonFixture("fixtures/v1p2/caliperEventToolUseUsedAnonymous.json");
+        JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
+    }
+
+    @After
+    public void teardown() {
+        event = null;
+    }
+
+    /**
+     * Build Tool Use Event
+     * @params profile, action
+     * @return event
+     */
+    private ToolUseEvent buildEvent(CaliperProfile profile, CaliperAction action) {
+        return ToolUseEvent.builder()
+            .context(context)
+            .id(id)
+            .profile(profile)
+            .actor(actor)
+            .action(action)
+            .object(object)
+            .eventTime(new DateTime(2018, 11, 15, 10, 15, 0, 0, DateTimeZone.UTC))
+            .edApp(edApp)
+            .group(group)
+            .membership(membership)
+            .build();
+    }
+}

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/ToolUseEventUsedAnonymousTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/ToolUseEventUsedAnonymousTest.java
@@ -57,16 +57,15 @@ public class ToolUseEventUsedAnonymousTest {
     private ToolUseEvent event;
 
     private static final String BASE_IRI = "https://example.edu";
-    private static final String BASE_TERM_IRI = "http://purl.imsglobal.org/caliper/";
 
     @Before
     public void setUp() throws Exception {
 
         CourseSection anonymousSection = CourseSection.builder()
-            .id(BASE_TERM_IRI.concat(EntityType.COURSE_SECTION.value()))
+            .id(EntityType.COURSE_SECTION.expandToIRI())
             .build();
 
-        Person anonymousPerson = Person.builder().id(BASE_TERM_IRI.concat(EntityType.PERSON.value())).build();
+        Person anonymousPerson = Person.builder().id(EntityType.PERSON.expandToIRI()).build();
 
         context = JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value());
 
@@ -81,7 +80,7 @@ public class ToolUseEventUsedAnonymousTest {
         group = anonymousSection;
 
         membership = Membership.builder()
-            .id(BASE_TERM_IRI.concat(EntityType.MEMBERSHIP.value()))
+            .id(EntityType.MEMBERSHIP.expandToIRI())
             .member(anonymousPerson)
             .organization(anonymousSection)
             .status(Status.ACTIVE)

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/ToolUseEventUsedWithProgressTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/ToolUseEventUsedWithProgressTest.java
@@ -26,7 +26,13 @@ import org.imsglobal.caliper.actions.CaliperAction;
 import org.imsglobal.caliper.context.CaliperJsonldContextIRI;
 import org.imsglobal.caliper.context.JsonldContext;
 import org.imsglobal.caliper.context.JsonldStringContext;
-import org.imsglobal.caliper.entities.agent.*;
+import org.imsglobal.caliper.entities.agent.CourseOffering;
+import org.imsglobal.caliper.entities.agent.CourseSection;
+import org.imsglobal.caliper.entities.agent.Membership;
+import org.imsglobal.caliper.entities.agent.Person;
+import org.imsglobal.caliper.entities.agent.Role;
+import org.imsglobal.caliper.entities.agent.SoftwareApplication;
+import org.imsglobal.caliper.entities.agent.Status;
 import org.imsglobal.caliper.entities.session.Session;
 import org.imsglobal.caliper.entities.use.AggregateMeasure;
 import org.imsglobal.caliper.entities.use.AggregateMeasureCollection;
@@ -164,8 +170,8 @@ public class ToolUseEventUsedWithProgressTest {
     }
 
     /**
-     * Build View event
-     * @param action
+     * Build Tool Use Event
+     * @param profile, action
      * @return event
      */
     private ToolUseEvent buildEvent(CaliperProfile profile, CaliperAction action) {

--- a/src/test/java/org/imsglobal/caliper/v1p2/identifiers/SystemIdentifierTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/identifiers/SystemIdentifierTest.java
@@ -1,0 +1,67 @@
+/**
+ * This file is part of IMS Caliper Analytics™ and is licensed to
+ * IMS Global Learning Consortium, Inc. (http://www.imsglobal.org)
+ * under one or more contributor license agreements.  See the NOTICE
+ * file distributed with this work for additional information.
+ *
+ * IMS Caliper is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * IMS Caliper is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.imsglobal.caliper.v1p2.identifiers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.imsglobal.caliper.TestUtils;
+import org.imsglobal.caliper.entities.agent.SoftwareApplication;
+import org.imsglobal.caliper.identifiers.SystemIdentifier;
+import org.imsglobal.caliper.identifiers.SystemIdentifierType;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
+
+@Category(org.imsglobal.caliper.UnitTest.class)
+public class SystemIdentifierTest {
+    private SystemIdentifier systemIdentifier;
+    private SoftwareApplication source;
+
+    private static final String BASE_IRI = "https://example.edu";
+
+    @Before
+    public void setUp() throws Exception {
+
+        source = SoftwareApplication.builder().id(BASE_IRI).build();
+
+        systemIdentifier = SystemIdentifier.builder()
+            .identifier(BASE_IRI.concat("/users/554433"))
+            .identifierType(SystemIdentifierType.LTI_USER_ID)
+            .source(source)
+            .build();
+    }
+
+    @Test
+    public void caliperEntitySerializesToJSON() throws Exception {
+        ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
+        String json = mapper.writeValueAsString(systemIdentifier);
+
+        String fixture = jsonFixture("fixtures/v1p2/caliperIdentifierSystemIdentifier.json");
+        JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
+    }
+
+    @After
+    public void teardown() {
+        systemIdentifier = null;
+    }
+}


### PR DESCRIPTION
This PR expands existing entities, introduces the notion of a `SystemIdentifier`, and provides new tests to cover additions and anonymous entities. The changes can be summarized as follows:

1) The `client` property was added to the `Session` entity, which also made necessary the addition of `host`, `ipAddress`, and `userAgent` to the `SoftwareApplication` entity. The `SessionClientTest` uses all these modifications.

2) A class for `SystemIdentifier` -- along with a `SystemIdentifierType` enum providing a controlled vocabulary for the `identifierType` property -- was introduced. A full implementation of the class required the addition of the `otherIdentifiers` property to the base `Entity` (the `AbstractEntity` class). The new `SystemIdentifierTest`, `CourseOfferingTest`, and `PersonTest` tests use these new features and modifications.

3) The `PersonAnonymousTest`, `CourseOfferingTest`, and `ToolUseEventUsedAnonymousTest` tests were added to demonstrate the possibility of using a Term IRI to make an entity anonymous. This was accomplished in the tests by concatenating the base IRI for a term (`http://purl.imsglobal.org/caliper/`) with a Term value pulled from the `EntityType` enum.

4) Minor changes were made `ToolUseEventUsedWithProgressTest` to make import statements explicit and correct a comment to the `buildEvent` method.