### PR TITLE
Adding and updating v1p2 Event tests

### DIFF
--- a/src/main/java/org/imsglobal/caliper/entities/Link.java
+++ b/src/main/java/org/imsglobal/caliper/entities/Link.java
@@ -21,7 +21,7 @@ package org.imsglobal.caliper.entities;
 /**
  * Implementation of a Link entity
  */
-public class Link extends AbstractEntity {
+public class Link extends AbstractEntity implements CaliperTargetable {
 
     /**
      * @param builder apply builder object properties to the Link object.

--- a/src/main/java/org/imsglobal/caliper/entities/annotation/SharedAnnotation.java
+++ b/src/main/java/org/imsglobal/caliper/entities/annotation/SharedAnnotation.java
@@ -75,6 +75,15 @@ public class SharedAnnotation extends AbstractAnnotation {
         }
 
         /**
+         * @param withAgent
+         * @return builder.
+         */
+        public T withAgent(CaliperAgent withAgent) {
+            this.withAgents.add(withAgent);
+            return self();
+        }
+
+        /**
          * Client invokes build method in order to create an immutable object.
          * @return a new instance of the SharedAnnotation.
          */

--- a/src/main/java/org/imsglobal/caliper/entities/annotation/TagAnnotation.java
+++ b/src/main/java/org/imsglobal/caliper/entities/annotation/TagAnnotation.java
@@ -74,6 +74,15 @@ public class TagAnnotation extends AbstractAnnotation {
         }
 
         /**
+         * @param tag
+         * @return builder.
+         */
+        public T tag(String tag) {
+            this.tags.add(tag);
+            return self();
+        }
+
+        /**
          * Client invokes build method in order to create an immutable object.
          * @return a new instance of the TagAnnotation.
          */

--- a/src/main/java/org/imsglobal/caliper/entities/question/MultiselectQuestion.java
+++ b/src/main/java/org/imsglobal/caliper/entities/question/MultiselectQuestion.java
@@ -108,6 +108,24 @@ public class MultiselectQuestion extends AbstractQuestion {
         }
 
         /**
+         * @param itemLabel
+         * @return builder.
+         */
+        public T itemLabel(String itemLabel) {
+            this.itemLabels.add(itemLabel);
+            return self();
+        }
+
+        /**
+         * @param itemValue
+         * @return builder.
+         */
+        public T itemValue(String itemValue) {
+            this.itemValues.add(itemValue);
+            return self();
+        }
+
+        /**
          * Client invokes build method in order to create an immutable object.
          * @return a new instance of the MultiselectQuestion.
          */

--- a/src/main/java/org/imsglobal/caliper/entities/resource/AbstractMediaObject.java
+++ b/src/main/java/org/imsglobal/caliper/entities/resource/AbstractMediaObject.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.imsglobal.caliper.entities.EntityType;
 
 import javax.annotation.Nullable;
-import java.util.List;
 
 /**
  * This class provides a skeletal implementation of the Resource interface

--- a/src/main/java/org/imsglobal/caliper/entities/response/MultiselectResponse.java
+++ b/src/main/java/org/imsglobal/caliper/entities/response/MultiselectResponse.java
@@ -68,6 +68,15 @@ public class MultiselectResponse extends AbstractResponse {
         }
 
         /**
+         * @param selection
+         * @return builder.
+         */
+        public T selection(String selection) {
+            this.selections.add(selection);
+            return self();
+        }
+        
+        /**
          * Client invokes build method in order to create an immutable object.
          * @return a new instance of MultiselectResponse.
          */

--- a/src/main/java/org/imsglobal/caliper/entities/response/RatingScaleResponse.java
+++ b/src/main/java/org/imsglobal/caliper/entities/response/RatingScaleResponse.java
@@ -60,10 +60,23 @@ public class RatingScaleResponse extends AbstractResponse {
             super.type(EntityType.RATING_SCALE_RESPONSE);
         }
 
+        /**
+         * @param selections
+         * @return builder.
+         */
         public T selections(List<String> selections) {
             if (selections != null) {
                 this.selections.addAll(selections);
             }
+            return self();
+        }
+
+        /**
+         * @param selection
+         * @return builder.
+         */
+        public T selection(String selection) {
+            this.selections.add(selection);
             return self();
         }
 

--- a/src/main/java/org/imsglobal/caliper/entities/scale/LikertScale.java
+++ b/src/main/java/org/imsglobal/caliper/entities/scale/LikertScale.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import org.imsglobal.caliper.entities.AbstractEntity;
-import org.imsglobal.caliper.entities.Entity;
 import org.imsglobal.caliper.entities.EntityType;
 
 import javax.annotation.Nullable;

--- a/src/main/java/org/imsglobal/caliper/entities/scale/MultiselectScale.java
+++ b/src/main/java/org/imsglobal/caliper/entities/scale/MultiselectScale.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import org.imsglobal.caliper.entities.AbstractEntity;
-import org.imsglobal.caliper.entities.Entity;
 import org.imsglobal.caliper.entities.EntityType;
 
 import javax.annotation.Nullable;

--- a/src/main/java/org/imsglobal/caliper/entities/search/SearchResponse.java
+++ b/src/main/java/org/imsglobal/caliper/entities/search/SearchResponse.java
@@ -19,13 +19,10 @@
 package org.imsglobal.caliper.entities.search;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 import org.imsglobal.caliper.entities.*;
 import org.imsglobal.caliper.entities.agent.SoftwareApplication;
 
 import javax.annotation.Nullable;
-import java.util.List;
 
 public class SearchResponse extends AbstractEntity implements CaliperGeneratable {
 

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/AnnotationEventBookmarkedTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/AnnotationEventBookmarkedTest.java
@@ -71,7 +71,6 @@ public class AnnotationEventBookmarkedTest {
 
         id = "urn:uuid:d4618c23-d612-4709-8d9a-478d87808067";
 
-
         actor = Person.builder().id(BASE_EDU_IRI.concat("/users/554433")).build();
         Person annotator = Person.builder().id(actor.getId()).coercedToId(true).build();
 

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/AnnotationEventBookmarkedTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/AnnotationEventBookmarkedTest.java
@@ -31,10 +31,10 @@ import org.imsglobal.caliper.entities.agent.Person;
 import org.imsglobal.caliper.entities.agent.Role;
 import org.imsglobal.caliper.entities.agent.SoftwareApplication;
 import org.imsglobal.caliper.entities.agent.Status;
-import org.imsglobal.caliper.entities.resource.DigitalResource;
-import org.imsglobal.caliper.entities.resource.DigitalResourceCollection;
+import org.imsglobal.caliper.entities.annotation.BookmarkAnnotation;
+import org.imsglobal.caliper.entities.resource.Page;
 import org.imsglobal.caliper.entities.session.Session;
-import org.imsglobal.caliper.events.ResourceManagementEvent;
+import org.imsglobal.caliper.events.AnnotationEvent;
 import org.imsglobal.caliper.profiles.CaliperProfile;
 import org.imsglobal.caliper.profiles.Profile;
 import org.joda.time.DateTime;
@@ -49,67 +49,73 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
 @Category(org.imsglobal.caliper.UnitTest.class)
-public class ResourceManagementEventCreatedTest {
+public class AnnotationEventBookmarkedTest {
     private JsonldContext context;
     private String id;
     private Person actor;
-    private CourseSection section;
-    private DigitalResource object;
-    private DigitalResourceCollection collection;
+    private Page object;
+    private BookmarkAnnotation generated;
+    private SoftwareApplication edApp;
     private CourseSection group;
     private Membership membership;
-    private ResourceManagementEvent event;
     private Session session;
-    private SoftwareApplication edApp;
+    private AnnotationEvent event;
 
-    private static final String BASE_IRI = "https://example.edu";
-    private static final String SECTION_IRI = BASE_IRI.concat("/terms/201801/courses/7/sections/1");
+    private static final String BASE_EDU_IRI = "https://example.edu";
+    private static final String BASE_COM_IRI = "https://example.com";
+    private static final String SECTION_IRI = BASE_EDU_IRI.concat("/terms/201601/courses/7/sections/1");
 
     @Before
     public void setUp() throws Exception {
         context = JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value());
-        id = "urn:uuid:0c81f804-62ee-4953-81c5-62d9579c4369";
-        actor = Person.builder().id(BASE_IRI.concat("/users/554433")).build();
 
-        collection = DigitalResourceCollection.builder()
-            .id(SECTION_IRI.concat("/resources/1"))
-            .name("Course Assets")
-            .isPartOf(CourseSection.builder().id(SECTION_IRI).build())
+        id = "urn:uuid:d4618c23-d612-4709-8d9a-478d87808067";
+
+
+        actor = Person.builder().id(BASE_EDU_IRI.concat("/users/554433")).build();
+        Person annotator = Person.builder().id(actor.getId()).coercedToId(true).build();
+
+        object = Page.builder()
+            .id(BASE_COM_IRI.concat("/#/texts/imscaliperimplguide/cfi/6/10!/4/2/2/2@0:0"))
+            .name("IMS Caliper Implementation Guide, pg 5")
+            .version("1.1")
             .build();
 
-        object = DigitalResource.builder()
-            .id(SECTION_IRI.concat("/resources/1/syllabus.pdf"))
-            .name("Course Syllabus")
-            .creator(actor)
-            .mediaType("application/pdf")
-            .isPartOf(collection)
-            .dateCreated(new DateTime(2018, 8, 2, 11, 32, 0, 0, DateTimeZone.UTC))
+        generated = BookmarkAnnotation.builder()
+            .id(BASE_COM_IRI.concat("/users/554433/texts/imscaliperimplguide/bookmarks/1"))
+            .annotated(Page.builder().id(object.getId()).coercedToId(true).build())
+            .annotator(annotator)
+            .bookmarkNotes("Caliper profiles model discrete learning activities or supporting activities that facilitate learning.")
+            .dateCreated(new DateTime(2016, 11, 15, 10, 15, 0, 0, DateTimeZone.UTC))
             .build();
 
-        edApp = SoftwareApplication.builder().id(BASE_IRI).coercedToId(true).build();
+        edApp = SoftwareApplication.builder()
+            .id(BASE_COM_IRI.concat("/reader"))
+            .name("ePub Reader")
+            .version("1.2.3").build();
 
         group = CourseSection.builder()
             .id(SECTION_IRI)
             .courseNumber("CPS 435-01")
-            .academicSession("Fall 2018")
+            .academicSession("Fall 2016")
             .build();
 
         membership = Membership.builder()
-            .id(BASE_IRI.concat("/terms/201801/courses/7/sections/1/rosters/1"))
-            .member(Person.builder().id(actor.getId()).coercedToId(true).build())
-            .organization(CourseSection.builder().id(SECTION_IRI).coercedToId(true).build())
+            .id(SECTION_IRI.concat("/rosters/1"))
+            .member(annotator)
+            .organization(CourseSection.builder().id(group.getId()).coercedToId(true).build())
             .status(Status.ACTIVE)
-            .role(Role.INSTRUCTOR)
-            .dateCreated(new DateTime(2018, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
+            .role(Role.LEARNER)
+            .dateCreated(new DateTime(2016, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
             .build();
 
         session = Session.builder()
-            .id(BASE_IRI.concat("/sessions/1f6442a482de72ea6ad134943812bff564a76259"))
-            .startedAtTime(new DateTime(2018, 11, 15, 10, 0, 0, 0, DateTimeZone.UTC))
+            .id(BASE_COM_IRI.concat("/sessions/1f6442a482de72ea6ad134943812bff564a76259"))
+            .startedAtTime(new DateTime(2016, 11, 15, 10, 0, 0, 0, DateTimeZone.UTC))
             .build();
 
         // Build event
-        event = buildEvent(Profile.RESOURCE_MANAGEMENT, Action.CREATED);
+        event = buildEvent(Profile.ANNOTATION, Action.BOOKMARKED);
     }
 
     @Test
@@ -117,14 +123,12 @@ public class ResourceManagementEventCreatedTest {
         ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
         String json = mapper.writeValueAsString(event);
 
-        String fixture = jsonFixture("fixtures/v1p2/caliperEventResourceManagementCreated.json");
+        String fixture = jsonFixture("fixtures/v1p2/caliperEventAnnotationBookmarked.json");
         JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Test(expected=IllegalArgumentException.class)
-    public void resourceManagementEventRejectsLaunchedAction() {
-        buildEvent(Profile.SURVEY, Action.LAUNCHED);
-    }
+    public void annotationEventRejectsCompletedAction() { buildEvent(Profile.ANNOTATION, Action.COMPLETED); }
 
     @After
     public void teardown() {
@@ -132,19 +136,20 @@ public class ResourceManagementEventCreatedTest {
     }
 
     /**
-     * Build ResourceManagementEvent.
+     * Build AnnotationEvent.
      * @param profile, action
      * @return event
      */
-    private ResourceManagementEvent buildEvent(CaliperProfile profile, CaliperAction action) {
-        return ResourceManagementEvent.builder()
+    private AnnotationEvent buildEvent(CaliperProfile profile, CaliperAction action) {
+        return AnnotationEvent.builder()
             .context(context)
-            .profile(profile)
             .id(id)
+            .profile(profile)
             .actor(actor)
             .action(action)
             .object(object)
-            .eventTime(new DateTime(2018, 11, 15, 10, 5, 0, 0, DateTimeZone.UTC))
+            .generated(generated)
+            .eventTime(new DateTime(2016, 11, 15, 10, 15, 0, 0, DateTimeZone.UTC))
             .edApp(edApp)
             .group(group)
             .membership(membership)

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/AnnotationEventSharedTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/AnnotationEventSharedTest.java
@@ -25,16 +25,17 @@ import org.imsglobal.caliper.actions.CaliperAction;
 import org.imsglobal.caliper.context.CaliperJsonldContextIRI;
 import org.imsglobal.caliper.context.JsonldContext;
 import org.imsglobal.caliper.context.JsonldStringContext;
+import org.imsglobal.caliper.entities.agent.CaliperAgent;
 import org.imsglobal.caliper.entities.agent.CourseSection;
 import org.imsglobal.caliper.entities.agent.Membership;
 import org.imsglobal.caliper.entities.agent.Person;
 import org.imsglobal.caliper.entities.agent.Role;
 import org.imsglobal.caliper.entities.agent.SoftwareApplication;
 import org.imsglobal.caliper.entities.agent.Status;
-import org.imsglobal.caliper.entities.resource.DigitalResource;
-import org.imsglobal.caliper.entities.resource.DigitalResourceCollection;
+import org.imsglobal.caliper.entities.annotation.SharedAnnotation;
+import org.imsglobal.caliper.entities.resource.Document;
 import org.imsglobal.caliper.entities.session.Session;
-import org.imsglobal.caliper.events.ResourceManagementEvent;
+import org.imsglobal.caliper.events.AnnotationEvent;
 import org.imsglobal.caliper.profiles.CaliperProfile;
 import org.imsglobal.caliper.profiles.Profile;
 import org.joda.time.DateTime;
@@ -46,70 +47,83 @@ import org.junit.experimental.categories.Category;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
 @Category(org.imsglobal.caliper.UnitTest.class)
-public class ResourceManagementEventCreatedTest {
+public class AnnotationEventSharedTest {
     private JsonldContext context;
     private String id;
     private Person actor;
-    private CourseSection section;
-    private DigitalResource object;
-    private DigitalResourceCollection collection;
+    private Document object;
+    private SharedAnnotation generated;
+    private SoftwareApplication edApp;
     private CourseSection group;
     private Membership membership;
-    private ResourceManagementEvent event;
     private Session session;
-    private SoftwareApplication edApp;
+    private List<CaliperAgent> agents;
+    private AnnotationEvent event;
 
-    private static final String BASE_IRI = "https://example.edu";
-    private static final String SECTION_IRI = BASE_IRI.concat("/terms/201801/courses/7/sections/1");
+    private static final String BASE_EDU_IRI = "https://example.edu";
+    private static final String BASE_COM_IRI = "https://example.com";
+    private static final String SECTION_IRI = BASE_EDU_IRI.concat("/terms/201601/courses/7/sections/1");
 
     @Before
     public void setUp() throws Exception {
         context = JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value());
-        id = "urn:uuid:0c81f804-62ee-4953-81c5-62d9579c4369";
-        actor = Person.builder().id(BASE_IRI.concat("/users/554433")).build();
 
-        collection = DigitalResourceCollection.builder()
-            .id(SECTION_IRI.concat("/resources/1"))
-            .name("Course Assets")
-            .isPartOf(CourseSection.builder().id(SECTION_IRI).build())
+        id = "urn:uuid:3bdab9e6-11cd-4a0f-9d09-8e363994176b";
+
+        actor = Person.builder().id(BASE_EDU_IRI.concat("/users/554433")).build();
+        Person annotator = Person.builder().id(actor.getId()).coercedToId(true).build();
+
+        object = Document.builder()
+            .id(BASE_COM_IRI.concat("/#/texts/imscaliperimplguide"))
+            .name("IMS Caliper Implementation Guide")
+            .version("1.1")
             .build();
 
-        object = DigitalResource.builder()
-            .id(SECTION_IRI.concat("/resources/1/syllabus.pdf"))
-            .name("Course Syllabus")
-            .creator(actor)
-            .mediaType("application/pdf")
-            .isPartOf(collection)
-            .dateCreated(new DateTime(2018, 8, 2, 11, 32, 0, 0, DateTimeZone.UTC))
+        agents = new ArrayList<CaliperAgent>();
+        agents.add(Person.builder().id(BASE_EDU_IRI.concat("/users/657585")).build());
+        agents.add(Person.builder().id(BASE_EDU_IRI.concat("/users/667788")).build());
+
+        generated = SharedAnnotation.builder()
+            .id(BASE_COM_IRI.concat("/users/554433/texts/imscaliperimplguide/shares/1"))
+            .annotated(Document.builder().id(object.getId()).coercedToId(true).build())
+            .annotator(annotator)
+            .withAgents(agents)
+            .dateCreated(new DateTime(2016, 11, 15, 10, 15, 0, 0, DateTimeZone.UTC))
             .build();
 
-        edApp = SoftwareApplication.builder().id(BASE_IRI).coercedToId(true).build();
+        edApp = SoftwareApplication.builder()
+            .id(BASE_COM_IRI.concat("/reader"))
+            .name("ePub Reader")
+            .version("1.2.3").build();
 
         group = CourseSection.builder()
             .id(SECTION_IRI)
             .courseNumber("CPS 435-01")
-            .academicSession("Fall 2018")
+            .academicSession("Fall 2016")
             .build();
 
         membership = Membership.builder()
-            .id(BASE_IRI.concat("/terms/201801/courses/7/sections/1/rosters/1"))
-            .member(Person.builder().id(actor.getId()).coercedToId(true).build())
-            .organization(CourseSection.builder().id(SECTION_IRI).coercedToId(true).build())
+            .id(SECTION_IRI.concat("/rosters/1"))
+            .member(annotator)
+            .organization(CourseSection.builder().id(group.getId()).coercedToId(true).build())
             .status(Status.ACTIVE)
-            .role(Role.INSTRUCTOR)
-            .dateCreated(new DateTime(2018, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
+            .role(Role.LEARNER)
+            .dateCreated(new DateTime(2016, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
             .build();
 
         session = Session.builder()
-            .id(BASE_IRI.concat("/sessions/1f6442a482de72ea6ad134943812bff564a76259"))
-            .startedAtTime(new DateTime(2018, 11, 15, 10, 0, 0, 0, DateTimeZone.UTC))
+            .id(BASE_COM_IRI.concat("/sessions/1f6442a482de72ea6ad134943812bff564a76259"))
+            .startedAtTime(new DateTime(2016, 11, 15, 10, 0, 0, 0, DateTimeZone.UTC))
             .build();
 
         // Build event
-        event = buildEvent(Profile.RESOURCE_MANAGEMENT, Action.CREATED);
+        event = buildEvent(Profile.ANNOTATION, Action.SHARED);
     }
 
     @Test
@@ -117,13 +131,13 @@ public class ResourceManagementEventCreatedTest {
         ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
         String json = mapper.writeValueAsString(event);
 
-        String fixture = jsonFixture("fixtures/v1p2/caliperEventResourceManagementCreated.json");
+        String fixture = jsonFixture("fixtures/v1p2/caliperEventAnnotationShared.json");
         JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Test(expected=IllegalArgumentException.class)
-    public void resourceManagementEventRejectsLaunchedAction() {
-        buildEvent(Profile.SURVEY, Action.LAUNCHED);
+    public void annotationEventRejectsGradedAction() {
+        buildEvent(Profile.ANNOTATION, Action.GRADED);
     }
 
     @After
@@ -132,19 +146,20 @@ public class ResourceManagementEventCreatedTest {
     }
 
     /**
-     * Build ResourceManagementEvent.
+     * Build AnnotationEvent.
      * @param profile, action
      * @return event
      */
-    private ResourceManagementEvent buildEvent(CaliperProfile profile, CaliperAction action) {
-        return ResourceManagementEvent.builder()
+    private AnnotationEvent buildEvent(CaliperProfile profile, CaliperAction action) {
+        return AnnotationEvent.builder()
             .context(context)
-            .profile(profile)
             .id(id)
+            .profile(profile)
             .actor(actor)
             .action(action)
             .object(object)
-            .eventTime(new DateTime(2018, 11, 15, 10, 5, 0, 0, DateTimeZone.UTC))
+            .generated(generated)
+            .eventTime(new DateTime(2016, 11, 15, 10, 15, 0, 0, DateTimeZone.UTC))
             .edApp(edApp)
             .group(group)
             .membership(membership)

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/AnnotationEventTaggedTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/AnnotationEventTaggedTest.java
@@ -31,10 +31,10 @@ import org.imsglobal.caliper.entities.agent.Person;
 import org.imsglobal.caliper.entities.agent.Role;
 import org.imsglobal.caliper.entities.agent.SoftwareApplication;
 import org.imsglobal.caliper.entities.agent.Status;
-import org.imsglobal.caliper.entities.resource.DigitalResource;
-import org.imsglobal.caliper.entities.resource.DigitalResourceCollection;
+import org.imsglobal.caliper.entities.annotation.TagAnnotation;
+import org.imsglobal.caliper.entities.resource.Page;
 import org.imsglobal.caliper.entities.session.Session;
-import org.imsglobal.caliper.events.ResourceManagementEvent;
+import org.imsglobal.caliper.events.AnnotationEvent;
 import org.imsglobal.caliper.profiles.CaliperProfile;
 import org.imsglobal.caliper.profiles.Profile;
 import org.joda.time.DateTime;
@@ -46,70 +46,86 @@ import org.junit.experimental.categories.Category;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
 @Category(org.imsglobal.caliper.UnitTest.class)
-public class ResourceManagementEventCreatedTest {
+public class AnnotationEventTaggedTest {
     private JsonldContext context;
     private String id;
     private Person actor;
-    private CourseSection section;
-    private DigitalResource object;
-    private DigitalResourceCollection collection;
+    private Page object;
+    private TagAnnotation generated;
+    private List<String> tags;
+    private SoftwareApplication edApp;
     private CourseSection group;
     private Membership membership;
-    private ResourceManagementEvent event;
     private Session session;
-    private SoftwareApplication edApp;
+    private AnnotationEvent event;
 
-    private static final String BASE_IRI = "https://example.edu";
-    private static final String SECTION_IRI = BASE_IRI.concat("/terms/201801/courses/7/sections/1");
+    private static final String BASE_EDU_IRI = "https://example.edu";
+    private static final String BASE_COM_IRI = "https://example.com";
+    private static final String SECTION_IRI = BASE_EDU_IRI.concat("/terms/201601/courses/7/sections/1");
 
     @Before
     public void setUp() throws Exception {
         context = JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value());
-        id = "urn:uuid:0c81f804-62ee-4953-81c5-62d9579c4369";
-        actor = Person.builder().id(BASE_IRI.concat("/users/554433")).build();
 
-        collection = DigitalResourceCollection.builder()
-            .id(SECTION_IRI.concat("/resources/1"))
-            .name("Course Assets")
-            .isPartOf(CourseSection.builder().id(SECTION_IRI).build())
+        id = "urn:uuid:b2009c63-2659-4cd2-b71e-6e03c498f02b";
+
+        actor = Person.builder().id(BASE_EDU_IRI.concat("/users/554433")).build();
+        Person annotator = Person.builder().id(actor.getId()).coercedToId(true).build();
+
+        object = Page.builder()
+            .id(BASE_COM_IRI.concat("/#/texts/imscaliperimplguide/cfi/6/10!/4/2/2/2@0:0"))
+            .name("IMS Caliper Implementation Guide, pg 5")
+            .version("1.1")
             .build();
 
-        object = DigitalResource.builder()
-            .id(SECTION_IRI.concat("/resources/1/syllabus.pdf"))
-            .name("Course Syllabus")
-            .creator(actor)
-            .mediaType("application/pdf")
-            .isPartOf(collection)
-            .dateCreated(new DateTime(2018, 8, 2, 11, 32, 0, 0, DateTimeZone.UTC))
+        List<String> tags = new ArrayList<>();
+        tags.add("profile");
+        tags.add("event");
+        tags.add("entity");
+
+        generated = TagAnnotation.builder()
+            .id(BASE_COM_IRI.concat("/users/554433/texts/imscaliperimplguide/tags/3"))
+            .annotated(Page.builder()
+                .id(BASE_COM_IRI.concat("/#/texts/imscaliperimplguide/cfi/6/10!/4/2/2/2@0:0"))
+                .coercedToId(true)
+                .build())
+            .annotator(annotator)
+            .tags(tags)
+            .dateCreated(new DateTime(2016, 11, 15, 10, 15, 0, 0, DateTimeZone.UTC))
             .build();
 
-        edApp = SoftwareApplication.builder().id(BASE_IRI).coercedToId(true).build();
+        edApp = SoftwareApplication.builder()
+            .id(BASE_COM_IRI.concat("/reader"))
+            .name("ePub Reader")
+            .version("1.2.3").build();
 
-        group = CourseSection.builder()
-            .id(SECTION_IRI)
+        group = CourseSection.builder().id(SECTION_IRI)
             .courseNumber("CPS 435-01")
-            .academicSession("Fall 2018")
+            .academicSession("Fall 2016")
             .build();
 
         membership = Membership.builder()
-            .id(BASE_IRI.concat("/terms/201801/courses/7/sections/1/rosters/1"))
-            .member(Person.builder().id(actor.getId()).coercedToId(true).build())
-            .organization(CourseSection.builder().id(SECTION_IRI).coercedToId(true).build())
+            .id(SECTION_IRI.concat("/rosters/1"))
+            .member(annotator)
+            .organization(CourseSection.builder().id(group.getId()).coercedToId(true).build())
             .status(Status.ACTIVE)
-            .role(Role.INSTRUCTOR)
-            .dateCreated(new DateTime(2018, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
+            .role(Role.LEARNER)
+            .dateCreated(new DateTime(2016, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
             .build();
 
         session = Session.builder()
-            .id(BASE_IRI.concat("/sessions/1f6442a482de72ea6ad134943812bff564a76259"))
-            .startedAtTime(new DateTime(2018, 11, 15, 10, 0, 0, 0, DateTimeZone.UTC))
+            .id(BASE_COM_IRI.concat("/sessions/1f6442a482de72ea6ad134943812bff564a76259"))
+            .startedAtTime(new DateTime(2016, 11, 15, 10, 0, 0, 0, DateTimeZone.UTC))
             .build();
 
         // Build event
-        event = buildEvent(Profile.RESOURCE_MANAGEMENT, Action.CREATED);
+        event = buildEvent(Profile.ANNOTATION, Action.TAGGED);
     }
 
     @Test
@@ -117,14 +133,12 @@ public class ResourceManagementEventCreatedTest {
         ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
         String json = mapper.writeValueAsString(event);
 
-        String fixture = jsonFixture("fixtures/v1p2/caliperEventResourceManagementCreated.json");
+        String fixture = jsonFixture("fixtures/v1p2/caliperEventAnnotationTagged.json");
         JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Test(expected=IllegalArgumentException.class)
-    public void resourceManagementEventRejectsLaunchedAction() {
-        buildEvent(Profile.SURVEY, Action.LAUNCHED);
-    }
+    public void annotationEventRejectsPausedAction() { buildEvent(Profile.ANNOTATION, Action.PAUSED); }
 
     @After
     public void teardown() {
@@ -132,19 +146,20 @@ public class ResourceManagementEventCreatedTest {
     }
 
     /**
-     * Build ResourceManagementEvent.
+     * Build AnnotationEvent.
      * @param profile, action
      * @return event
      */
-    private ResourceManagementEvent buildEvent(CaliperProfile profile, CaliperAction action) {
-        return ResourceManagementEvent.builder()
+    private AnnotationEvent buildEvent(CaliperProfile profile, CaliperAction action) {
+        return AnnotationEvent.builder()
             .context(context)
-            .profile(profile)
             .id(id)
+            .profile(profile)
             .actor(actor)
             .action(action)
             .object(object)
-            .eventTime(new DateTime(2018, 11, 15, 10, 5, 0, 0, DateTimeZone.UTC))
+            .generated(generated)
+            .eventTime(new DateTime(2016, 11, 15, 10, 15, 0, 0, DateTimeZone.UTC))
             .edApp(edApp)
             .group(group)
             .membership(membership)

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/AnnotationEventTaggedTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/AnnotationEventTaggedTest.java
@@ -58,7 +58,6 @@ public class AnnotationEventTaggedTest {
     private Person actor;
     private Page object;
     private TagAnnotation generated;
-    private List<String> tags;
     private SoftwareApplication edApp;
     private CourseSection group;
     private Membership membership;
@@ -87,16 +86,18 @@ public class AnnotationEventTaggedTest {
         List<String> tags = new ArrayList<>();
         tags.add("profile");
         tags.add("event");
-        tags.add("entity");
 
         generated = TagAnnotation.builder()
             .id(BASE_COM_IRI.concat("/users/554433/texts/imscaliperimplguide/tags/3"))
-            .annotated(Page.builder()
+            .annotated(
+                Page.builder()
                 .id(BASE_COM_IRI.concat("/#/texts/imscaliperimplguide/cfi/6/10!/4/2/2/2@0:0"))
                 .coercedToId(true)
-                .build())
+                .build()
+            )
             .annotator(annotator)
             .tags(tags)
+            .tag("entity")
             .dateCreated(new DateTime(2016, 11, 15, 10, 15, 0, 0, DateTimeZone.UTC))
             .build();
 

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/AssessmentEventStartedTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/AssessmentEventStartedTest.java
@@ -31,10 +31,10 @@ import org.imsglobal.caliper.entities.agent.Person;
 import org.imsglobal.caliper.entities.agent.Role;
 import org.imsglobal.caliper.entities.agent.SoftwareApplication;
 import org.imsglobal.caliper.entities.agent.Status;
-import org.imsglobal.caliper.entities.resource.DigitalResource;
-import org.imsglobal.caliper.entities.resource.DigitalResourceCollection;
+import org.imsglobal.caliper.entities.outcome.Attempt;
+import org.imsglobal.caliper.entities.resource.Assessment;
 import org.imsglobal.caliper.entities.session.Session;
-import org.imsglobal.caliper.events.ResourceManagementEvent;
+import org.imsglobal.caliper.events.AssessmentEvent;
 import org.imsglobal.caliper.profiles.CaliperProfile;
 import org.imsglobal.caliper.profiles.Profile;
 import org.joda.time.DateTime;
@@ -49,67 +49,73 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
 @Category(org.imsglobal.caliper.UnitTest.class)
-public class ResourceManagementEventCreatedTest {
+public class AssessmentEventStartedTest {
     private JsonldContext context;
     private String id;
     private Person actor;
-    private CourseSection section;
-    private DigitalResource object;
-    private DigitalResourceCollection collection;
+    private Assessment object;
+    private Attempt generated;
+    private SoftwareApplication edApp;
     private CourseSection group;
     private Membership membership;
-    private ResourceManagementEvent event;
     private Session session;
-    private SoftwareApplication edApp;
+    private AssessmentEvent event;
 
     private static final String BASE_IRI = "https://example.edu";
-    private static final String SECTION_IRI = BASE_IRI.concat("/terms/201801/courses/7/sections/1");
+    private static final String SECTION_IRI = BASE_IRI.concat("/terms/201601/courses/7/sections/1");
 
     @Before
     public void setUp() throws Exception {
         context = JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value());
-        id = "urn:uuid:0c81f804-62ee-4953-81c5-62d9579c4369";
+
+        id = "urn:uuid:27734504-068d-4596-861c-2315be33a2a2";
+
         actor = Person.builder().id(BASE_IRI.concat("/users/554433")).build();
+        Person assignee = Person.builder().id(actor.getId()).coercedToId(true).build();
 
-        collection = DigitalResourceCollection.builder()
-            .id(SECTION_IRI.concat("/resources/1"))
-            .name("Course Assets")
-            .isPartOf(CourseSection.builder().id(SECTION_IRI).build())
+        object = Assessment.builder()
+            .id(SECTION_IRI.concat("/assess/1"))
+            .name("Quiz One")
+            .dateToStartOn(new DateTime(2016, 11, 14, 5, 0, 0, 0, DateTimeZone.UTC))
+            .dateToSubmit(new DateTime(2016, 11, 18, 11, 59, 59, 0, DateTimeZone.UTC))
+            .maxAttempts(2)
+            .maxSubmits(2)
+            .maxScore(25)
+            .version("1.0")
             .build();
 
-        object = DigitalResource.builder()
-            .id(SECTION_IRI.concat("/resources/1/syllabus.pdf"))
-            .name("Course Syllabus")
-            .creator(actor)
-            .mediaType("application/pdf")
-            .isPartOf(collection)
-            .dateCreated(new DateTime(2018, 8, 2, 11, 32, 0, 0, DateTimeZone.UTC))
+        generated = Attempt.builder()
+            .id(SECTION_IRI.concat("/assess/1/users/554433/attempts/1"))
+            .assignable(Assessment.builder().id(object.getId()).coercedToId(true).build())
+            .assignee(assignee)
+            .count(1)
+            .dateCreated(new DateTime(2016, 11, 15, 10, 15, 0, 0, DateTimeZone.UTC))
+            .startedAtTime(new DateTime(2016, 11, 15, 10, 15, 0, 0, DateTimeZone.UTC))
             .build();
 
-        edApp = SoftwareApplication.builder().id(BASE_IRI).coercedToId(true).build();
+        edApp = SoftwareApplication.builder().id(BASE_IRI).version("v2").build();
 
         group = CourseSection.builder()
             .id(SECTION_IRI)
             .courseNumber("CPS 435-01")
-            .academicSession("Fall 2018")
+            .academicSession("Fall 2016")
             .build();
 
         membership = Membership.builder()
-            .id(BASE_IRI.concat("/terms/201801/courses/7/sections/1/rosters/1"))
-            .member(Person.builder().id(actor.getId()).coercedToId(true).build())
-            .organization(CourseSection.builder().id(SECTION_IRI).coercedToId(true).build())
+            .id(SECTION_IRI.concat("/rosters/1"))
+            .member(assignee)
+            .organization(CourseSection.builder().id(group.getId()).coercedToId(true).build())
             .status(Status.ACTIVE)
-            .role(Role.INSTRUCTOR)
-            .dateCreated(new DateTime(2018, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
+            .role(Role.LEARNER)
+            .dateCreated(new DateTime(2016, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
             .build();
 
         session = Session.builder()
             .id(BASE_IRI.concat("/sessions/1f6442a482de72ea6ad134943812bff564a76259"))
-            .startedAtTime(new DateTime(2018, 11, 15, 10, 0, 0, 0, DateTimeZone.UTC))
+            .startedAtTime(new DateTime(2016, 11, 15, 10, 0, 0, 0, DateTimeZone.UTC))
             .build();
 
-        // Build event
-        event = buildEvent(Profile.RESOURCE_MANAGEMENT, Action.CREATED);
+        event = buildEvent(Profile.ASSESSMENT, Action.STARTED);
     }
 
     @Test
@@ -117,13 +123,13 @@ public class ResourceManagementEventCreatedTest {
         ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
         String json = mapper.writeValueAsString(event);
 
-        String fixture = jsonFixture("fixtures/v1p2/caliperEventResourceManagementCreated.json");
+        String fixture = jsonFixture("fixtures/v1p2/caliperEventAssessmentStarted.json");
         JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Test(expected=IllegalArgumentException.class)
-    public void resourceManagementEventRejectsLaunchedAction() {
-        buildEvent(Profile.SURVEY, Action.LAUNCHED);
+    public void assessmentEventRejectsSearchedAction() {
+        buildEvent(Profile.ASSESSMENT, Action.SEARCHED);
     }
 
     @After
@@ -132,19 +138,20 @@ public class ResourceManagementEventCreatedTest {
     }
 
     /**
-     * Build ResourceManagementEvent.
+     * Build AssessmentEvent.
      * @param profile, action
      * @return event
      */
-    private ResourceManagementEvent buildEvent(CaliperProfile profile, CaliperAction action) {
-        return ResourceManagementEvent.builder()
+    private AssessmentEvent buildEvent(CaliperProfile profile, CaliperAction action) {
+        return AssessmentEvent.builder()
             .context(context)
-            .profile(profile)
             .id(id)
+            .profile(profile)
             .actor(actor)
             .action(action)
             .object(object)
-            .eventTime(new DateTime(2018, 11, 15, 10, 5, 0, 0, DateTimeZone.UTC))
+            .generated(generated)
+            .eventTime(new DateTime(2016, 11, 15, 10, 15, 0, 0, DateTimeZone.UTC))
             .edApp(edApp)
             .group(group)
             .membership(membership)

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/AssessmentEventSubmittedTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/AssessmentEventSubmittedTest.java
@@ -31,10 +31,10 @@ import org.imsglobal.caliper.entities.agent.Person;
 import org.imsglobal.caliper.entities.agent.Role;
 import org.imsglobal.caliper.entities.agent.SoftwareApplication;
 import org.imsglobal.caliper.entities.agent.Status;
-import org.imsglobal.caliper.entities.resource.DigitalResource;
-import org.imsglobal.caliper.entities.resource.DigitalResourceCollection;
+import org.imsglobal.caliper.entities.outcome.Attempt;
+import org.imsglobal.caliper.entities.resource.Assessment;
 import org.imsglobal.caliper.entities.session.Session;
-import org.imsglobal.caliper.events.ResourceManagementEvent;
+import org.imsglobal.caliper.events.AssessmentEvent;
 import org.imsglobal.caliper.profiles.CaliperProfile;
 import org.imsglobal.caliper.profiles.Profile;
 import org.joda.time.DateTime;
@@ -49,67 +49,74 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
 @Category(org.imsglobal.caliper.UnitTest.class)
-public class ResourceManagementEventCreatedTest {
+public class AssessmentEventSubmittedTest {
     private JsonldContext context;
     private String id;
     private Person actor;
-    private CourseSection section;
-    private DigitalResource object;
-    private DigitalResourceCollection collection;
+    private Assessment object;
+    private Attempt generated;
+    private SoftwareApplication edApp;
     private CourseSection group;
     private Membership membership;
-    private ResourceManagementEvent event;
     private Session session;
-    private SoftwareApplication edApp;
+    private AssessmentEvent event;
 
     private static final String BASE_IRI = "https://example.edu";
-    private static final String SECTION_IRI = BASE_IRI.concat("/terms/201801/courses/7/sections/1");
+    private static final String SECTION_IRI = BASE_IRI.concat("/terms/201601/courses/7/sections/1");
 
     @Before
     public void setUp() throws Exception {
         context = JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value());
-        id = "urn:uuid:0c81f804-62ee-4953-81c5-62d9579c4369";
+
+        id = "urn:uuid:dad88464-0c20-4a19-a1ba-ddf2f9c3ff33";
+
         actor = Person.builder().id(BASE_IRI.concat("/users/554433")).build();
 
-        collection = DigitalResourceCollection.builder()
-            .id(SECTION_IRI.concat("/resources/1"))
-            .name("Course Assets")
-            .isPartOf(CourseSection.builder().id(SECTION_IRI).build())
+        object = Assessment.builder()
+            .id(SECTION_IRI.concat("/assess/1"))
+            .name("Quiz One")
+            .dateToStartOn(new DateTime(2016, 11, 14, 5, 0, 0, 0, DateTimeZone.UTC))
+            .dateToSubmit(new DateTime(2016, 11, 18, 11, 59, 59, 0, DateTimeZone.UTC))
+            .maxAttempts(2)
+            .maxSubmits(2)
+            .maxScore(25)
+            .version("1.0")
             .build();
 
-        object = DigitalResource.builder()
-            .id(SECTION_IRI.concat("/resources/1/syllabus.pdf"))
-            .name("Course Syllabus")
-            .creator(actor)
-            .mediaType("application/pdf")
-            .isPartOf(collection)
-            .dateCreated(new DateTime(2018, 8, 2, 11, 32, 0, 0, DateTimeZone.UTC))
+        generated = Attempt.builder()
+            .id(SECTION_IRI.concat("/assess/1/users/554433/attempts/1"))
+            .assignable(Assessment.builder().id(object.getId()).coercedToId(true).build())
+            .assignee(Person.builder().id(actor.getId()).coercedToId(true).build())
+            .count(1)
+            .dateCreated(new DateTime(2016, 11, 15, 10, 15, 0, 0, DateTimeZone.UTC))
+            .startedAtTime(new DateTime(2016, 11, 15, 10, 15, 0, 0, DateTimeZone.UTC))
+            .endedAtTime(new DateTime(2016, 11, 15, 10, 25, 30, 0, DateTimeZone.UTC))
+            .duration("PT10M30S")
             .build();
 
-        edApp = SoftwareApplication.builder().id(BASE_IRI).coercedToId(true).build();
+        edApp = SoftwareApplication.builder().id(BASE_IRI).version("v2").build();
 
         group = CourseSection.builder()
             .id(SECTION_IRI)
             .courseNumber("CPS 435-01")
-            .academicSession("Fall 2018")
+            .academicSession("Fall 2016")
             .build();
 
         membership = Membership.builder()
-            .id(BASE_IRI.concat("/terms/201801/courses/7/sections/1/rosters/1"))
+            .id(SECTION_IRI.concat("/rosters/1"))
             .member(Person.builder().id(actor.getId()).coercedToId(true).build())
-            .organization(CourseSection.builder().id(SECTION_IRI).coercedToId(true).build())
+            .organization(CourseSection.builder().id(group.getId()).coercedToId(true).build())
             .status(Status.ACTIVE)
-            .role(Role.INSTRUCTOR)
-            .dateCreated(new DateTime(2018, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
+            .role(Role.LEARNER)
+            .dateCreated(new DateTime(2016, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
             .build();
 
         session = Session.builder()
             .id(BASE_IRI.concat("/sessions/1f6442a482de72ea6ad134943812bff564a76259"))
-            .startedAtTime(new DateTime(2018, 11, 15, 10, 0, 0, 0, DateTimeZone.UTC))
+            .startedAtTime(new DateTime(2016, 11, 15, 10, 0, 0, 0, DateTimeZone.UTC))
             .build();
 
-        // Build event
-        event = buildEvent(Profile.RESOURCE_MANAGEMENT, Action.CREATED);
+        event = buildEvent(Profile.ASSESSMENT, Action.SUBMITTED);
     }
 
     @Test
@@ -117,13 +124,13 @@ public class ResourceManagementEventCreatedTest {
         ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
         String json = mapper.writeValueAsString(event);
 
-        String fixture = jsonFixture("fixtures/v1p2/caliperEventResourceManagementCreated.json");
+        String fixture = jsonFixture("fixtures/v1p2/caliperEventAssessmentSubmitted.json");
         JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Test(expected=IllegalArgumentException.class)
-    public void resourceManagementEventRejectsLaunchedAction() {
-        buildEvent(Profile.SURVEY, Action.LAUNCHED);
+    public void assessmentEventRejectsSubscribedAction() {
+        buildEvent(Profile.ASSESSMENT, Action.SUBSCRIBED);
     }
 
     @After
@@ -132,20 +139,21 @@ public class ResourceManagementEventCreatedTest {
     }
 
     /**
-     * Build ResourceManagementEvent.
+     * Build AssessmentEvent.
      * @param profile, action
      * @return event
      */
-    private ResourceManagementEvent buildEvent(CaliperProfile profile, CaliperAction action) {
-        return ResourceManagementEvent.builder()
+    private AssessmentEvent buildEvent(CaliperProfile profile, CaliperAction action) {
+        return AssessmentEvent.builder()
             .context(context)
-            .profile(profile)
             .id(id)
             .actor(actor)
+            .profile(profile)
             .action(action)
             .object(object)
-            .eventTime(new DateTime(2018, 11, 15, 10, 5, 0, 0, DateTimeZone.UTC))
+            .eventTime(new DateTime(2016, 11, 15, 10, 25, 30, 0, DateTimeZone.UTC))
             .edApp(edApp)
+            .generated(generated)
             .group(group)
             .membership(membership)
             .session(session)

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/AssessmentItemEventCompletedTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/AssessmentItemEventCompletedTest.java
@@ -102,11 +102,13 @@ public class AssessmentItemEventCompletedTest {
         Attempt attempt = Attempt.builder()
             .id(SECTION_IRI.concat("/assess/1/items/3/users/554433/attempts/1"))
             .assignee(Person.builder().id(actor.getId()).coercedToId(true).build())
-            .assignable(AssessmentItem.builder()
+            .assignable(
+                AssessmentItem.builder()
                 .id(object.getId())
                 .name(object.getName())
                 .isPartOf(assessment)
-                .build())
+                .build()
+            )
             .isPartOf(assessmentAttempt)
             .count(1)
             .dateCreated(new DateTime(2016, 11, 15, 10, 15, 2, 0, DateTimeZone.UTC))
@@ -117,7 +119,6 @@ public class AssessmentItemEventCompletedTest {
         List<String> values = new ArrayList<String>();
         values.add("subject");
         values.add("object");
-        values.add("predicate");
 
         generated = FillinBlankResponse.builder()
             .id(BASE_IRI.concat("/terms/201601/courses/7/sections/1/assess/1/items/3/users/554433/responses/1"))
@@ -126,6 +127,7 @@ public class AssessmentItemEventCompletedTest {
             .startedAtTime(new DateTime(2016, 11, 15, 10, 15, 2, 0, DateTimeZone.UTC))
             .endedAtTime(new DateTime(2016, 11, 15, 10, 15, 12, 0, DateTimeZone.UTC))
             .values(values)
+            .value("predicate")
             .build();
 
         edApp = SoftwareApplication.builder().id(BASE_IRI).version("v2").build();
@@ -175,7 +177,6 @@ public class AssessmentItemEventCompletedTest {
 
     /**
      * Build AssessmentItemEvent.
-     *
      * @param profile, action
      * @return event
      */

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/AssessmentItemEventSkippedTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/AssessmentItemEventSkippedTest.java
@@ -31,10 +31,11 @@ import org.imsglobal.caliper.entities.agent.Person;
 import org.imsglobal.caliper.entities.agent.Role;
 import org.imsglobal.caliper.entities.agent.SoftwareApplication;
 import org.imsglobal.caliper.entities.agent.Status;
-import org.imsglobal.caliper.entities.resource.DigitalResource;
-import org.imsglobal.caliper.entities.resource.DigitalResourceCollection;
+import org.imsglobal.caliper.entities.outcome.Attempt;
+import org.imsglobal.caliper.entities.resource.Assessment;
+import org.imsglobal.caliper.entities.resource.AssessmentItem;
 import org.imsglobal.caliper.entities.session.Session;
-import org.imsglobal.caliper.events.ResourceManagementEvent;
+import org.imsglobal.caliper.events.AssessmentItemEvent;
 import org.imsglobal.caliper.profiles.CaliperProfile;
 import org.imsglobal.caliper.profiles.Profile;
 import org.joda.time.DateTime;
@@ -49,67 +50,68 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
 @Category(org.imsglobal.caliper.UnitTest.class)
-public class ResourceManagementEventCreatedTest {
+public class AssessmentItemEventSkippedTest {
     private JsonldContext context;
     private String id;
     private Person actor;
-    private CourseSection section;
-    private DigitalResource object;
-    private DigitalResourceCollection collection;
+    private AssessmentItem object;
+    private Attempt generated;
+    private SoftwareApplication edApp;
     private CourseSection group;
     private Membership membership;
-    private ResourceManagementEvent event;
     private Session session;
-    private SoftwareApplication edApp;
+    private AssessmentItemEvent event;
 
     private static final String BASE_IRI = "https://example.edu";
-    private static final String SECTION_IRI = BASE_IRI.concat("/terms/201801/courses/7/sections/1");
+    private static final String SECTION_IRI = BASE_IRI.concat("/terms/201601/courses/7/sections/1");
 
     @Before
     public void setUp() throws Exception {
         context = JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value());
-        id = "urn:uuid:0c81f804-62ee-4953-81c5-62d9579c4369";
+
+        id = "urn:uuid:04e27704-73bf-4d3c-912c-1b2da40aef8f";
+
         actor = Person.builder().id(BASE_IRI.concat("/users/554433")).build();
+        Person assignee = Person.builder().id(actor.getId()).coercedToId(true).build();
 
-        collection = DigitalResourceCollection.builder()
-            .id(SECTION_IRI.concat("/resources/1"))
-            .name("Course Assets")
-            .isPartOf(CourseSection.builder().id(SECTION_IRI).build())
+        object = AssessmentItem.builder()
+            .id(SECTION_IRI.concat("/assess/1/items/2"))
+            .name("Assessment Item 2")
+            .isPartOf(Assessment.builder().id(SECTION_IRI.concat("/assess/1")).build())
+            .version("1.0")
+            .dateToStartOn(new DateTime(2016, 11, 14, 5, 0, 0, 0, DateTimeZone.UTC))
+            .dateToSubmit(new DateTime(2016, 11, 18, 11, 59, 59, 0, DateTimeZone.UTC))
+            .maxAttempts(2)
+            .maxSubmits(2)
+            .maxScore(1)
+            .isTimeDependent(false)
+            .version("1.0")
             .build();
 
-        object = DigitalResource.builder()
-            .id(SECTION_IRI.concat("/resources/1/syllabus.pdf"))
-            .name("Course Syllabus")
-            .creator(actor)
-            .mediaType("application/pdf")
-            .isPartOf(collection)
-            .dateCreated(new DateTime(2018, 8, 2, 11, 32, 0, 0, DateTimeZone.UTC))
-            .build();
-
-        edApp = SoftwareApplication.builder().id(BASE_IRI).coercedToId(true).build();
+        edApp = SoftwareApplication.builder().id(BASE_IRI).version("v2").build();
 
         group = CourseSection.builder()
             .id(SECTION_IRI)
             .courseNumber("CPS 435-01")
-            .academicSession("Fall 2018")
+            .academicSession("Fall 2016")
             .build();
 
         membership = Membership.builder()
-            .id(BASE_IRI.concat("/terms/201801/courses/7/sections/1/rosters/1"))
-            .member(Person.builder().id(actor.getId()).coercedToId(true).build())
-            .organization(CourseSection.builder().id(SECTION_IRI).coercedToId(true).build())
+            .id(SECTION_IRI.concat("/rosters/1"))
+            .member(assignee)
+            .organization(CourseSection.builder().id(group.getId()).coercedToId(true).build())
             .status(Status.ACTIVE)
-            .role(Role.INSTRUCTOR)
-            .dateCreated(new DateTime(2018, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
+            .role(Role.LEARNER)
+            .dateCreated(new DateTime(2016, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
             .build();
 
         session = Session.builder()
             .id(BASE_IRI.concat("/sessions/1f6442a482de72ea6ad134943812bff564a76259"))
-            .startedAtTime(new DateTime(2018, 11, 15, 10, 0, 0, 0, DateTimeZone.UTC))
+            .startedAtTime(new DateTime(2016, 11, 15, 10, 0, 0, 0, DateTimeZone.UTC))
             .build();
 
         // Build event
-        event = buildEvent(Profile.RESOURCE_MANAGEMENT, Action.CREATED);
+        event = buildEvent(Profile.ASSESSMENT, Action.SKIPPED);
     }
 
     @Test
@@ -117,13 +119,13 @@ public class ResourceManagementEventCreatedTest {
         ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
         String json = mapper.writeValueAsString(event);
 
-        String fixture = jsonFixture("fixtures/v1p2/caliperEventResourceManagementCreated.json");
+        String fixture = jsonFixture("fixtures/v1p2/caliperEventAssessmentItemSkipped.json");
         JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Test(expected=IllegalArgumentException.class)
-    public void resourceManagementEventRejectsLaunchedAction() {
-        buildEvent(Profile.SURVEY, Action.LAUNCHED);
+    public void assessmentItemEventRejectsChangedVolumeAction() {
+        buildEvent(Profile.ASSESSMENT, Action.CHANGED_VOLUME);
     }
 
     @After
@@ -132,19 +134,19 @@ public class ResourceManagementEventCreatedTest {
     }
 
     /**
-     * Build ResourceManagementEvent.
+     * Build AssessmentItemEvent.
      * @param profile, action
      * @return event
      */
-    private ResourceManagementEvent buildEvent(CaliperProfile profile, CaliperAction action) {
-        return ResourceManagementEvent.builder()
+    private AssessmentItemEvent buildEvent(CaliperProfile profile, CaliperAction action) {
+        return AssessmentItemEvent.builder()
             .context(context)
-            .profile(profile)
             .id(id)
+            .profile(profile)
             .actor(actor)
             .action(action)
             .object(object)
-            .eventTime(new DateTime(2018, 11, 15, 10, 5, 0, 0, DateTimeZone.UTC))
+            .eventTime(new DateTime(2016, 11, 15, 10, 14, 30, 0, DateTimeZone.UTC))
             .edApp(edApp)
             .group(group)
             .membership(membership)

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/AssessmentItemEventStartedTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/AssessmentItemEventStartedTest.java
@@ -31,10 +31,11 @@ import org.imsglobal.caliper.entities.agent.Person;
 import org.imsglobal.caliper.entities.agent.Role;
 import org.imsglobal.caliper.entities.agent.SoftwareApplication;
 import org.imsglobal.caliper.entities.agent.Status;
-import org.imsglobal.caliper.entities.resource.DigitalResource;
-import org.imsglobal.caliper.entities.resource.DigitalResourceCollection;
+import org.imsglobal.caliper.entities.outcome.Attempt;
+import org.imsglobal.caliper.entities.resource.Assessment;
+import org.imsglobal.caliper.entities.resource.AssessmentItem;
 import org.imsglobal.caliper.entities.session.Session;
-import org.imsglobal.caliper.events.ResourceManagementEvent;
+import org.imsglobal.caliper.events.AssessmentItemEvent;
 import org.imsglobal.caliper.profiles.CaliperProfile;
 import org.imsglobal.caliper.profiles.Profile;
 import org.joda.time.DateTime;
@@ -49,67 +50,78 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
 @Category(org.imsglobal.caliper.UnitTest.class)
-public class ResourceManagementEventCreatedTest {
+public class AssessmentItemEventStartedTest {
     private JsonldContext context;
     private String id;
     private Person actor;
-    private CourseSection section;
-    private DigitalResource object;
-    private DigitalResourceCollection collection;
+    private AssessmentItem object;
+    private Attempt generated;
+    private SoftwareApplication edApp;
     private CourseSection group;
     private Membership membership;
-    private ResourceManagementEvent event;
     private Session session;
-    private SoftwareApplication edApp;
+    private AssessmentItemEvent event;
 
     private static final String BASE_IRI = "https://example.edu";
-    private static final String SECTION_IRI = BASE_IRI.concat("/terms/201801/courses/7/sections/1");
+    private static final String SECTION_IRI = BASE_IRI.concat("/terms/201601/courses/7/sections/1");
 
     @Before
     public void setUp() throws Exception {
         context = JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value());
-        id = "urn:uuid:0c81f804-62ee-4953-81c5-62d9579c4369";
+
+        id = "urn:uuid:1b557176-ba67-4624-b060-6bee670a3d8e";
+
         actor = Person.builder().id(BASE_IRI.concat("/users/554433")).build();
+        Person assignee = Person.builder().id(actor.getId()).coercedToId(true).build();
 
-        collection = DigitalResourceCollection.builder()
-            .id(SECTION_IRI.concat("/resources/1"))
-            .name("Course Assets")
-            .isPartOf(CourseSection.builder().id(SECTION_IRI).build())
+        object = AssessmentItem.builder()
+            .id(SECTION_IRI.concat("/assess/1/items/3"))
+            .name("Assessment Item 3")
+            .isPartOf(Assessment.builder().id(SECTION_IRI.concat("/assess/1")).build())
+            .version("1.0")
+            .dateToStartOn(new DateTime(2016, 11, 14, 5, 0, 0, 0, DateTimeZone.UTC))
+            .dateToSubmit(new DateTime(2016, 11, 18, 11, 59, 59, 0, DateTimeZone.UTC))
+            .maxAttempts(2)
+            .maxSubmits(2)
+            .maxScore(1)
+            .isTimeDependent(false)
+            .version("1.0")
             .build();
 
-        object = DigitalResource.builder()
-            .id(SECTION_IRI.concat("/resources/1/syllabus.pdf"))
-            .name("Course Syllabus")
-            .creator(actor)
-            .mediaType("application/pdf")
-            .isPartOf(collection)
-            .dateCreated(new DateTime(2018, 8, 2, 11, 32, 0, 0, DateTimeZone.UTC))
+        generated = Attempt.builder()
+            .id(SECTION_IRI.concat("/assess/1/items/3/users/554433/attempts/1"))
+            .assignable(AssessmentItem.builder().id(object.getId()).coercedToId(true).build())
+            .assignee(assignee)
+            .isPartOf(Attempt.builder().id(SECTION_IRI.concat("/assess/1/users/554433/attempts/1")).build())
+            .count(1)
+            .dateCreated(new DateTime(2016, 11, 15, 10, 15, 0, 0, DateTimeZone.UTC))
+            .startedAtTime(new DateTime(2016, 11, 15, 10, 15, 0, 0, DateTimeZone.UTC))
             .build();
 
-        edApp = SoftwareApplication.builder().id(BASE_IRI).coercedToId(true).build();
+        edApp = SoftwareApplication.builder().id(BASE_IRI).version("v2").build();
 
         group = CourseSection.builder()
             .id(SECTION_IRI)
             .courseNumber("CPS 435-01")
-            .academicSession("Fall 2018")
+            .academicSession("Fall 2016")
             .build();
 
         membership = Membership.builder()
-            .id(BASE_IRI.concat("/terms/201801/courses/7/sections/1/rosters/1"))
-            .member(Person.builder().id(actor.getId()).coercedToId(true).build())
-            .organization(CourseSection.builder().id(SECTION_IRI).coercedToId(true).build())
+            .id(SECTION_IRI.concat("/rosters/1"))
+            .member(assignee)
+            .organization(CourseSection.builder().id(group.getId()).coercedToId(true).build())
             .status(Status.ACTIVE)
-            .role(Role.INSTRUCTOR)
-            .dateCreated(new DateTime(2018, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
+            .role(Role.LEARNER)
+            .dateCreated(new DateTime(2016, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
             .build();
 
         session = Session.builder()
             .id(BASE_IRI.concat("/sessions/1f6442a482de72ea6ad134943812bff564a76259"))
-            .startedAtTime(new DateTime(2018, 11, 15, 10, 0, 0, 0, DateTimeZone.UTC))
+            .startedAtTime(new DateTime(2016, 11, 15, 10, 0, 0, 0, DateTimeZone.UTC))
             .build();
 
         // Build event
-        event = buildEvent(Profile.RESOURCE_MANAGEMENT, Action.CREATED);
+        event = buildEvent(Profile.ASSESSMENT, Action.STARTED);
     }
 
     @Test
@@ -117,13 +129,13 @@ public class ResourceManagementEventCreatedTest {
         ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
         String json = mapper.writeValueAsString(event);
 
-        String fixture = jsonFixture("fixtures/v1p2/caliperEventResourceManagementCreated.json");
+        String fixture = jsonFixture("fixtures/v1p2/caliperEventAssessmentItemStarted.json");
         JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Test(expected=IllegalArgumentException.class)
-    public void resourceManagementEventRejectsLaunchedAction() {
-        buildEvent(Profile.SURVEY, Action.LAUNCHED);
+    public void assessmentItemEventRejectsChangedVolumeAction() {
+        buildEvent(Profile.ASSESSMENT, Action.CHANGED_VOLUME);
     }
 
     @After
@@ -132,19 +144,20 @@ public class ResourceManagementEventCreatedTest {
     }
 
     /**
-     * Build ResourceManagementEvent.
+     * Build AssessmentItemEvent.
      * @param profile, action
      * @return event
      */
-    private ResourceManagementEvent buildEvent(CaliperProfile profile, CaliperAction action) {
-        return ResourceManagementEvent.builder()
+    private AssessmentItemEvent buildEvent(CaliperProfile profile, CaliperAction action) {
+        return AssessmentItemEvent.builder()
             .context(context)
-            .profile(profile)
             .id(id)
+            .profile(profile)
             .actor(actor)
             .action(action)
             .object(object)
-            .eventTime(new DateTime(2018, 11, 15, 10, 5, 0, 0, DateTimeZone.UTC))
+            .generated(generated)
+            .eventTime(new DateTime(2016, 11, 15, 10, 15, 0, 0, DateTimeZone.UTC))
             .edApp(edApp)
             .group(group)
             .membership(membership)

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/FeedbackEventCommentedTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/FeedbackEventCommentedTest.java
@@ -25,7 +25,12 @@ import org.imsglobal.caliper.actions.CaliperAction;
 import org.imsglobal.caliper.context.CaliperJsonldContextIRI;
 import org.imsglobal.caliper.context.JsonldContext;
 import org.imsglobal.caliper.context.JsonldStringContext;
-import org.imsglobal.caliper.entities.agent.*;
+import org.imsglobal.caliper.entities.agent.CourseSection;
+import org.imsglobal.caliper.entities.agent.Membership;
+import org.imsglobal.caliper.entities.agent.Person;
+import org.imsglobal.caliper.entities.agent.Role;
+import org.imsglobal.caliper.entities.agent.SoftwareApplication;
+import org.imsglobal.caliper.entities.agent.Status;
 import org.imsglobal.caliper.entities.resource.DigitalResource;
 import org.imsglobal.caliper.entities.resource.DigitalResourceCollection;
 import org.imsglobal.caliper.entities.session.Session;
@@ -42,8 +47,6 @@ import org.junit.experimental.categories.Category;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 
-import java.util.List;
-
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
 @Category(org.imsglobal.caliper.UnitTest.class)
@@ -56,7 +59,6 @@ public class FeedbackEventCommentedTest {
     private Comment generated;
     private DigitalResourceCollection collection;
     private CourseSection group;
-    private List<CaliperAgent> creators;
     private Membership membership;
     private FeedbackEvent event;
     private Session session;
@@ -129,14 +131,19 @@ public class FeedbackEventCommentedTest {
         JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
     }
 
+    @Test(expected=IllegalArgumentException.class)
+    public void feedbackEventRejectsCopiedAction() {
+        buildEvent(Profile.FEEDBACK, Action.COPIED);
+    }
+
     @After
     public void teardown() {
         event = null;
     }
 
     /**
-     * Build Media event.
-     * @param action
+     * Build FeedbackEvent.
+     * @param profile, action
      * @return event
      */
     private FeedbackEvent buildEvent(CaliperProfile profile, CaliperAction action) {

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/FeedbackEventRankedTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/FeedbackEventRankedTest.java
@@ -19,7 +19,7 @@
 package org.imsglobal.caliper.v1p2.events;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.fest.util.Lists;
+import com.google.common.collect.Lists;
 import org.imsglobal.caliper.TestUtils;
 import org.imsglobal.caliper.actions.Action;
 import org.imsglobal.caliper.actions.CaliperAction;
@@ -101,19 +101,19 @@ public class FeedbackEventRankedTest {
         itemLabels.add("Strongly Disagree");
         itemLabels.add("Disagree");
         itemLabels.add("Agree");
-        itemLabels.add("Strongly Agree");
 
         List<String> itemValues = Lists.newArrayList();
         itemValues.add("-2");
         itemValues.add("-1");
         itemValues.add("1");
-        itemValues.add("2");
 
         scale = LikertScale.builder()
             .id(BASE_IRI.concat("/scale/2"))
             .scalePoints(4)
             .itemLabels(itemLabels)
+            .itemLabel("Strongly Agree")
             .itemValues(itemValues)
+            .itemValue("2")
             .build();
 
         question = RatingScaleQuestion.builder()

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/FeedbackEventRankedTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/FeedbackEventRankedTest.java
@@ -26,7 +26,12 @@ import org.imsglobal.caliper.actions.CaliperAction;
 import org.imsglobal.caliper.context.CaliperJsonldContextIRI;
 import org.imsglobal.caliper.context.JsonldContext;
 import org.imsglobal.caliper.context.JsonldStringContext;
-import org.imsglobal.caliper.entities.agent.*;
+import org.imsglobal.caliper.entities.agent.CourseSection;
+import org.imsglobal.caliper.entities.agent.Membership;
+import org.imsglobal.caliper.entities.agent.Person;
+import org.imsglobal.caliper.entities.agent.Role;
+import org.imsglobal.caliper.entities.agent.SoftwareApplication;
+import org.imsglobal.caliper.entities.agent.Status;
 import org.imsglobal.caliper.entities.resource.DigitalResource;
 import org.imsglobal.caliper.entities.resource.DigitalResourceCollection;
 import org.imsglobal.caliper.entities.scale.LikertScale;
@@ -46,7 +51,6 @@ import org.junit.experimental.categories.Category;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
@@ -61,7 +65,6 @@ public class FeedbackEventRankedTest {
     private Rating generated;
     private DigitalResourceCollection collection;
     private CourseSection group;
-    private List<CaliperAgent> creators;
     private Membership membership;
     private RatingScaleQuestion question;
     private Comment ratingComment;
@@ -78,8 +81,6 @@ public class FeedbackEventRankedTest {
         context = JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value());
         id = "urn:uuid:a502e4fc-24c1-11e9-ab14-d663bd873d93";
         actor = Person.builder().id(BASE_IRI.concat("/users/554433")).build();
-        creators = new ArrayList<CaliperAgent>();
-        creators.add(actor);
         section = CourseSection.builder().id(SECTION_IRI).build();
 
         collection = DigitalResourceCollection.builder()
@@ -91,7 +92,6 @@ public class FeedbackEventRankedTest {
         object = DigitalResource.builder()
             .id(SECTION_IRI.concat("/resources/1/syllabus.pdf"))
             .name("Course Syllabus")
-            //.creators(creators)
             .mediaType("application/pdf")
             .isPartOf(collection)
             .dateCreated(new DateTime(2018, 8, 2, 11, 32, 0, 0, DateTimeZone.UTC))
@@ -175,14 +175,19 @@ public class FeedbackEventRankedTest {
         JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
     }
 
+    @Test(expected=IllegalArgumentException.class)
+    public void feedbackEventRejectsCopiedAction() {
+        buildEvent(Profile.FEEDBACK, Action.COPIED);
+    }
+
     @After
     public void teardown() {
         event = null;
     }
 
     /**
-     * Build Media event.
-     * @param action
+     * Build FeedbackEvent.
+     * @param profile, action
      * @return event
      */
     private FeedbackEvent buildEvent(CaliperProfile profile, CaliperAction action) {

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/ForumEventSubscribedTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/ForumEventSubscribedTest.java
@@ -31,10 +31,9 @@ import org.imsglobal.caliper.entities.agent.Person;
 import org.imsglobal.caliper.entities.agent.Role;
 import org.imsglobal.caliper.entities.agent.SoftwareApplication;
 import org.imsglobal.caliper.entities.agent.Status;
-import org.imsglobal.caliper.entities.resource.DigitalResource;
-import org.imsglobal.caliper.entities.resource.DigitalResourceCollection;
+import org.imsglobal.caliper.entities.resource.Forum;
 import org.imsglobal.caliper.entities.session.Session;
-import org.imsglobal.caliper.events.ResourceManagementEvent;
+import org.imsglobal.caliper.events.ForumEvent;
 import org.imsglobal.caliper.profiles.CaliperProfile;
 import org.imsglobal.caliper.profiles.Profile;
 import org.joda.time.DateTime;
@@ -49,67 +48,59 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
 @Category(org.imsglobal.caliper.UnitTest.class)
-public class ResourceManagementEventCreatedTest {
+public class ForumEventSubscribedTest {
     private JsonldContext context;
     private String id;
     private Person actor;
-    private CourseSection section;
-    private DigitalResource object;
-    private DigitalResourceCollection collection;
+    private Forum object;
+    private SoftwareApplication edApp;
     private CourseSection group;
     private Membership membership;
-    private ResourceManagementEvent event;
     private Session session;
-    private SoftwareApplication edApp;
+    private ForumEvent event;
 
     private static final String BASE_IRI = "https://example.edu";
-    private static final String SECTION_IRI = BASE_IRI.concat("/terms/201801/courses/7/sections/1");
+    private static final String SECTION_IRI = BASE_IRI.concat("/terms/201601/courses/7/sections/1");
 
     @Before
     public void setUp() throws Exception {
         context = JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value());
-        id = "urn:uuid:0c81f804-62ee-4953-81c5-62d9579c4369";
+
+        id = "urn:uuid:a2f41f9c-d57d-4400-b3fe-716b9026334e";
+
         actor = Person.builder().id(BASE_IRI.concat("/users/554433")).build();
 
-        collection = DigitalResourceCollection.builder()
-            .id(SECTION_IRI.concat("/resources/1"))
-            .name("Course Assets")
+        object = Forum.builder()
+            .id(SECTION_IRI.concat("/forums/1"))
+            .name("Caliper Forum")
             .isPartOf(CourseSection.builder().id(SECTION_IRI).build())
+            .dateCreated(new DateTime(2016, 9, 14, 11, 0, 0, 0, DateTimeZone.UTC))
             .build();
 
-        object = DigitalResource.builder()
-            .id(SECTION_IRI.concat("/resources/1/syllabus.pdf"))
-            .name("Course Syllabus")
-            .creator(actor)
-            .mediaType("application/pdf")
-            .isPartOf(collection)
-            .dateCreated(new DateTime(2018, 8, 2, 11, 32, 0, 0, DateTimeZone.UTC))
-            .build();
-
-        edApp = SoftwareApplication.builder().id(BASE_IRI).coercedToId(true).build();
+        edApp = SoftwareApplication.builder().id(BASE_IRI.concat("/forums")).version("v2").build();
 
         group = CourseSection.builder()
-            .id(SECTION_IRI)
+            .id(BASE_IRI.concat("/terms/201601/courses/7/sections/1"))
             .courseNumber("CPS 435-01")
-            .academicSession("Fall 2018")
+            .academicSession("Fall 2016")
             .build();
 
         membership = Membership.builder()
-            .id(BASE_IRI.concat("/terms/201801/courses/7/sections/1/rosters/1"))
+            .id(BASE_IRI.concat("/terms/201601/courses/7/sections/1/rosters/1"))
             .member(Person.builder().id(actor.getId()).coercedToId(true).build())
-            .organization(CourseSection.builder().id(SECTION_IRI).coercedToId(true).build())
+            .organization(CourseSection.builder().id(group.getId()).coercedToId(true).build())
             .status(Status.ACTIVE)
-            .role(Role.INSTRUCTOR)
-            .dateCreated(new DateTime(2018, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
+            .role(Role.LEARNER)
+            .dateCreated(new DateTime(2016, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
             .build();
 
         session = Session.builder()
             .id(BASE_IRI.concat("/sessions/1f6442a482de72ea6ad134943812bff564a76259"))
-            .startedAtTime(new DateTime(2018, 11, 15, 10, 0, 0, 0, DateTimeZone.UTC))
+            .startedAtTime(new DateTime(2016, 11, 15, 10, 0, 0, 0, DateTimeZone.UTC))
             .build();
 
         // Build event
-        event = buildEvent(Profile.RESOURCE_MANAGEMENT, Action.CREATED);
+        event = buildEvent(Profile.FORUM, Action.SUBSCRIBED);
     }
 
     @Test
@@ -117,13 +108,13 @@ public class ResourceManagementEventCreatedTest {
         ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
         String json = mapper.writeValueAsString(event);
 
-        String fixture = jsonFixture("fixtures/v1p2/caliperEventResourceManagementCreated.json");
+        String fixture = jsonFixture("fixtures/v1p2/caliperEventForumSubscribed.json");
         JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Test(expected=IllegalArgumentException.class)
-    public void resourceManagementEventRejectsLaunchedAction() {
-        buildEvent(Profile.SURVEY, Action.LAUNCHED);
+    public void forumEventRejectsStartedAction() {
+        buildEvent(Profile.FORUM, Action.STARTED);
     }
 
     @After
@@ -132,19 +123,19 @@ public class ResourceManagementEventCreatedTest {
     }
 
     /**
-     * Build ResourceManagementEvent.
+     * Build ForumEvent.
      * @param profile, action
      * @return event
      */
-    private ResourceManagementEvent buildEvent(CaliperProfile profile, CaliperAction action) {
-        return ResourceManagementEvent.builder()
+    private ForumEvent buildEvent(CaliperProfile profile, CaliperAction action) {
+        return ForumEvent.builder()
             .context(context)
-            .profile(profile)
             .id(id)
+            .profile(profile)
             .actor(actor)
             .action(action)
             .object(object)
-            .eventTime(new DateTime(2018, 11, 15, 10, 5, 0, 0, DateTimeZone.UTC))
+            .eventTime(new DateTime(2016, 11, 15, 10, 16, 0, 0, DateTimeZone.UTC))
             .edApp(edApp)
             .group(group)
             .membership(membership)

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/ForumEventSubscribedThinnedTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/ForumEventSubscribedThinnedTest.java
@@ -28,13 +28,10 @@ import org.imsglobal.caliper.context.JsonldStringContext;
 import org.imsglobal.caliper.entities.agent.CourseSection;
 import org.imsglobal.caliper.entities.agent.Membership;
 import org.imsglobal.caliper.entities.agent.Person;
-import org.imsglobal.caliper.entities.agent.Role;
 import org.imsglobal.caliper.entities.agent.SoftwareApplication;
-import org.imsglobal.caliper.entities.agent.Status;
-import org.imsglobal.caliper.entities.resource.DigitalResource;
-import org.imsglobal.caliper.entities.resource.DigitalResourceCollection;
+import org.imsglobal.caliper.entities.resource.Forum;
 import org.imsglobal.caliper.entities.session.Session;
-import org.imsglobal.caliper.events.ResourceManagementEvent;
+import org.imsglobal.caliper.events.ForumEvent;
 import org.imsglobal.caliper.profiles.CaliperProfile;
 import org.imsglobal.caliper.profiles.Profile;
 import org.joda.time.DateTime;
@@ -49,18 +46,16 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
 @Category(org.imsglobal.caliper.UnitTest.class)
-public class ResourceManagementEventCreatedTest {
+public class ForumEventSubscribedThinnedTest {
     private JsonldContext context;
     private String id;
     private Person actor;
-    private CourseSection section;
-    private DigitalResource object;
-    private DigitalResourceCollection collection;
+    private Forum object;
+    private SoftwareApplication edApp;
     private CourseSection group;
     private Membership membership;
-    private ResourceManagementEvent event;
     private Session session;
-    private SoftwareApplication edApp;
+    private ForumEvent event;
 
     private static final String BASE_IRI = "https://example.edu";
     private static final String SECTION_IRI = BASE_IRI.concat("/terms/201801/courses/7/sections/1");
@@ -68,48 +63,33 @@ public class ResourceManagementEventCreatedTest {
     @Before
     public void setUp() throws Exception {
         context = JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value());
-        id = "urn:uuid:0c81f804-62ee-4953-81c5-62d9579c4369";
-        actor = Person.builder().id(BASE_IRI.concat("/users/554433")).build();
 
-        collection = DigitalResourceCollection.builder()
-            .id(SECTION_IRI.concat("/resources/1"))
-            .name("Course Assets")
-            .isPartOf(CourseSection.builder().id(SECTION_IRI).build())
-            .build();
+        id = "urn:uuid:a2f41f9c-d57d-4400-b3fe-716b9026334e";
 
-        object = DigitalResource.builder()
-            .id(SECTION_IRI.concat("/resources/1/syllabus.pdf"))
-            .name("Course Syllabus")
-            .creator(actor)
-            .mediaType("application/pdf")
-            .isPartOf(collection)
-            .dateCreated(new DateTime(2018, 8, 2, 11, 32, 0, 0, DateTimeZone.UTC))
-            .build();
+        actor = Person.builder().id(BASE_IRI.concat("/users/554433")).coercedToId(true).build();
 
-        edApp = SoftwareApplication.builder().id(BASE_IRI).coercedToId(true).build();
+        object = Forum.builder().id(SECTION_IRI.concat("/forums/1")).coercedToId(true).build();
+
+        edApp = SoftwareApplication.builder().id(BASE_IRI.concat("/forums")).coercedToId(true).build();
 
         group = CourseSection.builder()
-            .id(SECTION_IRI)
-            .courseNumber("CPS 435-01")
-            .academicSession("Fall 2018")
+            .id(BASE_IRI.concat("/terms/201801/courses/7/sections/1"))
+            .coercedToId(true)
             .build();
+
 
         membership = Membership.builder()
             .id(BASE_IRI.concat("/terms/201801/courses/7/sections/1/rosters/1"))
-            .member(Person.builder().id(actor.getId()).coercedToId(true).build())
-            .organization(CourseSection.builder().id(SECTION_IRI).coercedToId(true).build())
-            .status(Status.ACTIVE)
-            .role(Role.INSTRUCTOR)
-            .dateCreated(new DateTime(2018, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
+            .coercedToId(true)
             .build();
 
         session = Session.builder()
-            .id(BASE_IRI.concat("/sessions/1f6442a482de72ea6ad134943812bff564a76259"))
-            .startedAtTime(new DateTime(2018, 11, 15, 10, 0, 0, 0, DateTimeZone.UTC))
-            .build();
+                .id(BASE_IRI.concat("/sessions/1f6442a482de72ea6ad134943812bff564a76259"))
+                .coercedToId(true)
+                .build();
 
         // Build event
-        event = buildEvent(Profile.RESOURCE_MANAGEMENT, Action.CREATED);
+        event = buildEvent(Profile.FORUM, Action.SUBSCRIBED);
     }
 
     @Test
@@ -117,13 +97,13 @@ public class ResourceManagementEventCreatedTest {
         ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
         String json = mapper.writeValueAsString(event);
 
-        String fixture = jsonFixture("fixtures/v1p2/caliperEventResourceManagementCreated.json");
+        String fixture = jsonFixture("fixtures/v1p2/caliperEventForumSubscribedThinned.json");
         JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Test(expected=IllegalArgumentException.class)
-    public void resourceManagementEventRejectsLaunchedAction() {
-        buildEvent(Profile.SURVEY, Action.LAUNCHED);
+    public void forumEventRejectsStartedAction() {
+        buildEvent(Profile.FORUM, Action.STARTED);
     }
 
     @After
@@ -132,19 +112,19 @@ public class ResourceManagementEventCreatedTest {
     }
 
     /**
-     * Build ResourceManagementEvent.
+     * Build ForumEvent.
      * @param profile, action
      * @return event
      */
-    private ResourceManagementEvent buildEvent(CaliperProfile profile, CaliperAction action) {
-        return ResourceManagementEvent.builder()
+    private ForumEvent buildEvent(CaliperProfile profile, CaliperAction action) {
+        return ForumEvent.builder()
             .context(context)
-            .profile(profile)
             .id(id)
+            .profile(profile)
             .actor(actor)
             .action(action)
             .object(object)
-            .eventTime(new DateTime(2018, 11, 15, 10, 5, 0, 0, DateTimeZone.UTC))
+            .eventTime(new DateTime(2018, 11, 15, 10, 16, 0, 0, DateTimeZone.UTC))
             .edApp(edApp)
             .group(group)
             .membership(membership)

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/ForumEventSubscribedThinnedTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/ForumEventSubscribedThinnedTest.java
@@ -77,7 +77,6 @@ public class ForumEventSubscribedThinnedTest {
             .coercedToId(true)
             .build();
 
-
         membership = Membership.builder()
             .id(BASE_IRI.concat("/terms/201801/courses/7/sections/1/rosters/1"))
             .coercedToId(true)

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/GeneralEventCreatedTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/GeneralEventCreatedTest.java
@@ -25,14 +25,9 @@ import org.imsglobal.caliper.actions.CaliperAction;
 import org.imsglobal.caliper.context.CaliperJsonldContextIRI;
 import org.imsglobal.caliper.context.JsonldContext;
 import org.imsglobal.caliper.context.JsonldStringContext;
-import org.imsglobal.caliper.entities.agent.CourseSection;
-import org.imsglobal.caliper.entities.agent.Membership;
 import org.imsglobal.caliper.entities.agent.Person;
-import org.imsglobal.caliper.entities.agent.Role;
-import org.imsglobal.caliper.entities.agent.SoftwareApplication;
-import org.imsglobal.caliper.entities.agent.Status;
-import org.imsglobal.caliper.entities.EntityType;
-import org.imsglobal.caliper.events.ToolUseEvent;
+import org.imsglobal.caliper.entities.resource.Document;
+import org.imsglobal.caliper.events.Event;
 import org.imsglobal.caliper.profiles.CaliperProfile;
 import org.imsglobal.caliper.profiles.Profile;
 import org.joda.time.DateTime;
@@ -47,48 +42,33 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
 @Category(org.imsglobal.caliper.UnitTest.class)
-public class ToolUseEventUsedAnonymousTest {
+public class GeneralEventCreatedTest {
     private JsonldContext context;
     private String id;
     private Person actor;
-    private SoftwareApplication object, edApp;
-    private CourseSection group;
-    private Membership membership;
-    private ToolUseEvent event;
+    private Document object;
+    private Event event;
 
     private static final String BASE_IRI = "https://example.edu";
+    private static final String SECTION_IRI = BASE_IRI.concat("/terms/201601/courses/7/sections/1");
 
     @Before
     public void setUp() throws Exception {
-
-        CourseSection anonymousSection = CourseSection.builder()
-            .id(EntityType.COURSE_SECTION.expandToIRI())
-            .build();
-
-        Person anonymousPerson = Person.builder().id(EntityType.PERSON.expandToIRI()).build();
-
         context = JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value());
 
-        id = "urn:uuid:7c0fc54b-cf2a-426f-9203-b2c97fb77bfd";
+        id = "urn:uuid:3a648e68-f00d-4c08-aa59-8738e1884f2c";
 
-        actor = anonymousPerson;
+        actor = Person.builder().id(BASE_IRI.concat("/users/554433")).build();
 
-        object = SoftwareApplication.builder().id(BASE_IRI).build();
-
-        edApp = SoftwareApplication.builder().id(BASE_IRI).coercedToId(true).build();
-
-        group = anonymousSection;
-
-        membership = Membership.builder()
-            .id(EntityType.MEMBERSHIP.expandToIRI())
-            .member(anonymousPerson)
-            .organization(anonymousSection)
-            .status(Status.ACTIVE)
-            .role(Role.LEARNER)
+        object = Document.builder()
+            .id(SECTION_IRI.concat("/resources/123"))
+            .name("Course Syllabus")
+            .dateCreated(new DateTime(2016, 11, 12, 7, 15, 0, 0, DateTimeZone.UTC))
+            .version("1")
             .build();
 
         // Build event
-        event = buildEvent(Profile.TOOL_USE, Action.USED);
+        event = buildEvent(Profile.GENERAL, Action.CREATED);
     }
 
     @Test
@@ -96,7 +76,7 @@ public class ToolUseEventUsedAnonymousTest {
         ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
         String json = mapper.writeValueAsString(event);
 
-        String fixture = jsonFixture("fixtures/v1p2/caliperEventToolUseUsedAnonymous.json");
+        String fixture = jsonFixture("fixtures/v1p2/caliperEventGeneralCreated.json");
         JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
     }
 
@@ -106,22 +86,19 @@ public class ToolUseEventUsedAnonymousTest {
     }
 
     /**
-     * Build ToolUseEvent.
-     * @params profile, action
+     * Build Event.
+     * @param profile, action
      * @return event
      */
-    private ToolUseEvent buildEvent(CaliperProfile profile, CaliperAction action) {
-        return ToolUseEvent.builder()
+    private Event buildEvent(CaliperProfile profile, CaliperAction action) {
+        return Event.builder()
             .context(context)
             .id(id)
             .profile(profile)
             .actor(actor)
             .action(action)
             .object(object)
-            .eventTime(new DateTime(2018, 11, 15, 10, 15, 0, 0, DateTimeZone.UTC))
-            .edApp(edApp)
-            .group(group)
-            .membership(membership)
+            .eventTime(new DateTime(2016, 11, 15, 10, 15, 0, 0, DateTimeZone.UTC))
             .build();
     }
 }

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/GeneralEventModifiedExtendedTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/GeneralEventModifiedExtendedTest.java
@@ -19,20 +19,17 @@
 package org.imsglobal.caliper.v1p2.events;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import org.imsglobal.caliper.TestUtils;
 import org.imsglobal.caliper.actions.Action;
 import org.imsglobal.caliper.actions.CaliperAction;
 import org.imsglobal.caliper.context.CaliperJsonldContextIRI;
 import org.imsglobal.caliper.context.JsonldContext;
 import org.imsglobal.caliper.context.JsonldStringContext;
-import org.imsglobal.caliper.entities.agent.CourseSection;
-import org.imsglobal.caliper.entities.agent.Membership;
 import org.imsglobal.caliper.entities.agent.Person;
-import org.imsglobal.caliper.entities.agent.Role;
-import org.imsglobal.caliper.entities.agent.SoftwareApplication;
-import org.imsglobal.caliper.entities.agent.Status;
-import org.imsglobal.caliper.entities.EntityType;
-import org.imsglobal.caliper.events.ToolUseEvent;
+import org.imsglobal.caliper.entities.resource.Document;
+import org.imsglobal.caliper.events.Event;
 import org.imsglobal.caliper.profiles.CaliperProfile;
 import org.imsglobal.caliper.profiles.Profile;
 import org.joda.time.DateTime;
@@ -44,51 +41,63 @@ import org.junit.experimental.categories.Category;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
 @Category(org.imsglobal.caliper.UnitTest.class)
-public class ToolUseEventUsedAnonymousTest {
+public class GeneralEventModifiedExtendedTest {
     private JsonldContext context;
     private String id;
     private Person actor;
-    private SoftwareApplication object, edApp;
-    private CourseSection group;
-    private Membership membership;
-    private ToolUseEvent event;
+    private Document object;
+    private Map<String, Object> extensions;
+    private Event event;
 
     private static final String BASE_IRI = "https://example.edu";
+    private static final String SECTION_IRI = BASE_IRI.concat("/terms/201601/courses/7/sections/1");
 
     @Before
     public void setUp() throws Exception {
-
-        CourseSection anonymousSection = CourseSection.builder()
-            .id(EntityType.COURSE_SECTION.expandToIRI())
-            .build();
-
-        Person anonymousPerson = Person.builder().id(EntityType.PERSON.expandToIRI()).build();
-
         context = JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value());
 
-        id = "urn:uuid:7c0fc54b-cf2a-426f-9203-b2c97fb77bfd";
+        DateTime dateCreated = new DateTime(2016, 11, 12, 7, 15, 0, 0, DateTimeZone.UTC);
 
-        actor = anonymousPerson;
+        id = "urn:uuid:5973dcd9-3126-4dcc-8fd8-8153a155361c";
 
-        object = SoftwareApplication.builder().id(BASE_IRI).build();
+        actor = Person.builder().id(BASE_IRI.concat("/users/554433")).build();
 
-        edApp = SoftwareApplication.builder().id(BASE_IRI).coercedToId(true).build();
-
-        group = anonymousSection;
-
-        membership = Membership.builder()
-            .id(EntityType.MEMBERSHIP.expandToIRI())
-            .member(anonymousPerson)
-            .organization(anonymousSection)
-            .status(Status.ACTIVE)
-            .role(Role.LEARNER)
+        object = Document.builder()
+            .id(SECTION_IRI.concat("/resources/123?version=3"))
+            .name("Course Syllabus")
+            .dateCreated(dateCreated)
+            .dateModified(new DateTime(2016, 11, 15, 10, 15, 0, 0, DateTimeZone.UTC))
+            .version("3")
             .build();
 
+        Document versionTwo = Document.builder()
+            .id("https://example.edu/terms/201601/courses/7/sections/1/resources/123?version=2")
+            .dateCreated(dateCreated)
+            .dateModified(new DateTime(2016, 11, 13, 11, 0, 0, 0, DateTimeZone.UTC))
+            .version("2")
+            .build();
+
+        Document versionOne = Document.builder()
+            .id("https://example.edu/terms/201601/courses/7/sections/1/resources/123?version=1")
+            .dateCreated(dateCreated)
+            .version("1")
+            .build();
+
+        Document[] versionArray = {versionOne, versionTwo};
+        List<Document> versions = Lists.newArrayList();
+        versions.addAll(Arrays.asList(versionArray));
+        extensions = Maps.newHashMap();
+        extensions.put("archive", versions);
+
         // Build event
-        event = buildEvent(Profile.TOOL_USE, Action.USED);
+        event = buildEvent(Profile.GENERAL, Action.MODIFIED);
     }
 
     @Test
@@ -96,7 +105,7 @@ public class ToolUseEventUsedAnonymousTest {
         ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
         String json = mapper.writeValueAsString(event);
 
-        String fixture = jsonFixture("fixtures/v1p2/caliperEventToolUseUsedAnonymous.json");
+        String fixture = jsonFixture("fixtures/v1p2/caliperEventGeneralModifiedExtended.json");
         JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
     }
 
@@ -106,22 +115,20 @@ public class ToolUseEventUsedAnonymousTest {
     }
 
     /**
-     * Build ToolUseEvent.
-     * @params profile, action
+     * Build Event.
+     * @param profile, action
      * @return event
      */
-    private ToolUseEvent buildEvent(CaliperProfile profile, CaliperAction action) {
-        return ToolUseEvent.builder()
+    private Event buildEvent(CaliperProfile profile, CaliperAction action) {
+        return Event.builder()
             .context(context)
             .id(id)
             .profile(profile)
             .actor(actor)
             .action(action)
             .object(object)
-            .eventTime(new DateTime(2018, 11, 15, 10, 15, 0, 0, DateTimeZone.UTC))
-            .edApp(edApp)
-            .group(group)
-            .membership(membership)
+            .eventTime(new DateTime(2016, 11, 15, 10, 15, 0, 0, DateTimeZone.UTC))
+            .extensions(extensions)
             .build();
     }
 }

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/GradeEventGradedItemTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/GradeEventGradedItemTest.java
@@ -26,15 +26,13 @@ import org.imsglobal.caliper.context.CaliperJsonldContextIRI;
 import org.imsglobal.caliper.context.JsonldContext;
 import org.imsglobal.caliper.context.JsonldStringContext;
 import org.imsglobal.caliper.entities.agent.CourseSection;
-import org.imsglobal.caliper.entities.agent.Membership;
 import org.imsglobal.caliper.entities.agent.Person;
-import org.imsglobal.caliper.entities.agent.Role;
 import org.imsglobal.caliper.entities.agent.SoftwareApplication;
-import org.imsglobal.caliper.entities.agent.Status;
-import org.imsglobal.caliper.entities.resource.Questionnaire;
-import org.imsglobal.caliper.entities.resource.QuestionnaireItem;
-import org.imsglobal.caliper.entities.session.Session;
-import org.imsglobal.caliper.events.QuestionnaireEvent;
+import org.imsglobal.caliper.entities.outcome.Attempt;
+import org.imsglobal.caliper.entities.outcome.Score;
+import org.imsglobal.caliper.entities.resource.Assessment;
+import org.imsglobal.caliper.entities.resource.AssessmentItem;
+import org.imsglobal.caliper.events.GradeEvent;
 import org.imsglobal.caliper.profiles.CaliperProfile;
 import org.imsglobal.caliper.profiles.Profile;
 import org.joda.time.DateTime;
@@ -49,65 +47,74 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
 @Category(org.imsglobal.caliper.UnitTest.class)
-public class QuestionnaireEventStartedTest {
+public class GradeEventGradedItemTest {
     private JsonldContext context;
     private String id;
-    private Person actor;
-    private Questionnaire object;
+    private SoftwareApplication actor, edApp;
+    private Person learner;
+    private Attempt object;
+    private Score generated;
     private CourseSection group;
-    private SoftwareApplication edApp;
-    private Membership membership;
-    private Session session;
-    private QuestionnaireEvent event;
+    private GradeEvent event;
 
     private static final String BASE_IRI = "https://example.edu";
-    private static final String SECTION_IRI = BASE_IRI.concat("/terms/201801/courses/7/sections/1");
+    private static final String SECTION_IRI = BASE_IRI.concat("/terms/201601/courses/7/sections/1");
 
     @Before
     public void setUp() throws Exception {
         context = JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value());
-        id = "urn:uuid:23995ed4-3c6b-11e9-b210-d663bd873d93";
-        actor = Person.builder().id(BASE_IRI.concat("/users/554433")).build();
 
-        QuestionnaireItem itemOne = QuestionnaireItem.builder()
-            .id(BASE_IRI.concat("/surveys/100/questionnaires/30/items/1"))
+        id = "urn:uuid:12c05c4e-253f-4073-9f29-5786f3ff3f36";
+
+        actor = SoftwareApplication.builder().id(BASE_IRI.concat("/autograder")).version("v2").build();
+        learner = Person.builder().id(BASE_IRI.concat("/users/554433")).build();
+
+        Assessment assessment = Assessment.builder()
+            .id(SECTION_IRI.concat("/assess/1"))
             .build();
 
-        QuestionnaireItem itemTwo = QuestionnaireItem.builder()
-            .id(BASE_IRI.concat("/surveys/100/questionnaires/30/items/2"))
+        AssessmentItem assessmentItem = AssessmentItem.builder()
+            .id(SECTION_IRI.concat("/assess/1/items/3"))
+            .name("Assessment Item 3")
+            .isPartOf(assessment)
             .build();
 
-        object = Questionnaire.builder()
-            .id(BASE_IRI.concat("/surveys/100/questionnaires/30"))
-            .item(itemOne)
-            .item(itemTwo)
-            .dateCreated(new DateTime(2018, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
+        Attempt parentAttempt = Attempt.builder()
+            .id(SECTION_IRI.concat("/assess/1/users/554433/attempts/1"))
+            .coercedToId(true)
             .build();
 
-        group = CourseSection.builder()
-            .id(SECTION_IRI)
-            .courseNumber("CPS 435-01")
-            .academicSession("Fall 2018")
+        object = Attempt.builder()
+            .id(SECTION_IRI.concat("/assess/1/items/3/users/554433/attempts/1"))
+            .assignable(assessmentItem)
+            .assignee(learner)
+            .count(1)
+            .isPartOf(parentAttempt)
+            .dateCreated(new DateTime(2016, 11, 15, 10, 15, 2, 0, DateTimeZone.UTC))
+            .startedAtTime(new DateTime(2016, 11, 15, 10, 15, 2, 0, DateTimeZone.UTC))
+            .endedAtTime(new DateTime(2016, 11, 15, 10, 15, 12, 0, DateTimeZone.UTC))
             .build();
 
-        membership = Membership.builder()
-            .id(SECTION_IRI.concat("/rosters/1"))
-            .role(Role.LEARNER)
-            .member(Person.builder().id(BASE_IRI.concat("/users/554433")).coercedToId(true).build())
-            .organization(CourseSection.builder().id(SECTION_IRI).coercedToId(true).build())
-            .status(Status.ACTIVE)
-            .dateCreated(new DateTime(2018, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
-            .build();
-
-        session = Session.builder()
-            .id(BASE_IRI.concat("/sessions/f095bbd391ea4a5dd639724a40b606e98a631823"))
-            .startedAtTime(new DateTime(2018, 11, 12, 10, 0, 0, 0, DateTimeZone.UTC))
+        generated = Score.builder()
+            .id(SECTION_IRI.concat("/assess/1/items/3/users/554433/attempts/1/scores/1"))
+            .attempt(Attempt.builder().id(SECTION_IRI.concat("/assess/1/users/554433/attempts/1")).coercedToId(true).build())
+            .maxScore(5)
+            .scoreGiven(5)
+            .scoredBy(SoftwareApplication.builder().id(BASE_IRI.concat("/autograder")).coercedToId(true).build())
+            .comment("auto-graded exam")
+            .dateCreated(new DateTime(2016, 11, 15, 10, 55, 5, 0, DateTimeZone.UTC))
             .build();
 
         edApp = SoftwareApplication.builder().id(BASE_IRI).coercedToId(true).build();
 
-        // Build event
-        event = buildEvent(Profile.SURVEY, Action.STARTED);
+        group = CourseSection.builder()
+            .id(BASE_IRI.concat("/terms/201601/courses/7/sections/1"))
+            .courseNumber("CPS 435-01")
+            .academicSession("Fall 2016")
+            .build();
+
+        // Build Outcome Event
+        event = buildEvent(Profile.GRADING, Action.GRADED);
     }
 
     @Test
@@ -115,13 +122,13 @@ public class QuestionnaireEventStartedTest {
         ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
         String json = mapper.writeValueAsString(event);
 
-        String fixture = jsonFixture("fixtures/v1p2/caliperEventQuestionnaireStarted.json");
+        String fixture = jsonFixture("fixtures/v1p2/caliperEventGradeGradedItem.json");
         JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Test(expected=IllegalArgumentException.class)
-    public void questionnaireEventRejectsCommentedAction() {
-        buildEvent(Profile.SURVEY, Action.COMMENTED);
+    public void gradeEventRejectsHidAction() {
+        buildEvent(Profile.GRADING, Action.HID);
     }
 
     @After
@@ -130,23 +137,22 @@ public class QuestionnaireEventStartedTest {
     }
 
     /**
-     * Build QuestionnaireEvent.
+     * Build GradeEvent.
      * @param profile, action
      * @return event
      */
-    private QuestionnaireEvent buildEvent(CaliperProfile profile, CaliperAction action) {
-        return QuestionnaireEvent.builder()
+    private GradeEvent buildEvent(CaliperProfile profile, CaliperAction action) {
+        return GradeEvent.builder()
             .context(context)
             .id(id)
             .profile(profile)
             .actor(actor)
             .action(action)
             .object(object)
-            .eventTime(new DateTime(2018, 11, 12, 10, 15, 0, 0, DateTimeZone.UTC))
+            .generated(generated)
             .edApp(edApp)
             .group(group)
-            .membership(membership)
-            .session(session)
+            .eventTime(new DateTime(2016, 11, 15, 10, 57, 6, 0, DateTimeZone.UTC))
             .build();
     }
 }

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/GradeEventGradedTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/GradeEventGradedTest.java
@@ -26,15 +26,12 @@ import org.imsglobal.caliper.context.CaliperJsonldContextIRI;
 import org.imsglobal.caliper.context.JsonldContext;
 import org.imsglobal.caliper.context.JsonldStringContext;
 import org.imsglobal.caliper.entities.agent.CourseSection;
-import org.imsglobal.caliper.entities.agent.Membership;
 import org.imsglobal.caliper.entities.agent.Person;
-import org.imsglobal.caliper.entities.agent.Role;
 import org.imsglobal.caliper.entities.agent.SoftwareApplication;
-import org.imsglobal.caliper.entities.agent.Status;
-import org.imsglobal.caliper.entities.resource.DigitalResource;
-import org.imsglobal.caliper.entities.resource.DigitalResourceCollection;
-import org.imsglobal.caliper.entities.session.Session;
-import org.imsglobal.caliper.events.ResourceManagementEvent;
+import org.imsglobal.caliper.entities.outcome.Attempt;
+import org.imsglobal.caliper.entities.outcome.Score;
+import org.imsglobal.caliper.entities.resource.Assessment;
+import org.imsglobal.caliper.events.GradeEvent;
 import org.imsglobal.caliper.profiles.CaliperProfile;
 import org.imsglobal.caliper.profiles.Profile;
 import org.joda.time.DateTime;
@@ -49,67 +46,60 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
 @Category(org.imsglobal.caliper.UnitTest.class)
-public class ResourceManagementEventCreatedTest {
+public class GradeEventGradedTest {
     private JsonldContext context;
     private String id;
-    private Person actor;
-    private CourseSection section;
-    private DigitalResource object;
-    private DigitalResourceCollection collection;
+    private SoftwareApplication actor, edApp;
+    private Person learner;
+    private Attempt object;
+    private Assessment assignable;
+    private Score generated;
     private CourseSection group;
-    private Membership membership;
-    private ResourceManagementEvent event;
-    private Session session;
-    private SoftwareApplication edApp;
+    private GradeEvent event;
 
     private static final String BASE_IRI = "https://example.edu";
-    private static final String SECTION_IRI = BASE_IRI.concat("/terms/201801/courses/7/sections/1");
 
     @Before
     public void setUp() throws Exception {
         context = JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value());
-        id = "urn:uuid:0c81f804-62ee-4953-81c5-62d9579c4369";
-        actor = Person.builder().id(BASE_IRI.concat("/users/554433")).build();
 
-        collection = DigitalResourceCollection.builder()
-            .id(SECTION_IRI.concat("/resources/1"))
-            .name("Course Assets")
-            .isPartOf(CourseSection.builder().id(SECTION_IRI).build())
+        id = "urn:uuid:a50ca17f-5971-47bb-8fca-4e6e6879001d";
+
+        actor = SoftwareApplication.builder().id(BASE_IRI.concat("/autograder")).version("v2").build();
+        learner = Person.builder().id(BASE_IRI.concat("/users/554433")).build();
+        assignable = Assessment.builder().id(BASE_IRI.concat("/terms/201601/courses/7/sections/1/assess/1")).build();
+
+        object = Attempt.builder()
+            .id(BASE_IRI.concat("/terms/201601/courses/7/sections/1/assess/1/users/554433/attempts/1"))
+            .assignable(assignable)
+            .assignee(learner)
+            .count(1)
+            .dateCreated(new DateTime(2016, 11, 15, 10, 5, 0, 0, DateTimeZone.UTC))
+            .startedAtTime(new DateTime(2016, 11, 15, 10, 5, 0, 0, DateTimeZone.UTC))
+            .endedAtTime(new DateTime(2016, 11, 15, 10, 55, 12, 0, DateTimeZone.UTC))
+            .duration("PT50M12S")
             .build();
 
-        object = DigitalResource.builder()
-            .id(SECTION_IRI.concat("/resources/1/syllabus.pdf"))
-            .name("Course Syllabus")
-            .creator(actor)
-            .mediaType("application/pdf")
-            .isPartOf(collection)
-            .dateCreated(new DateTime(2018, 8, 2, 11, 32, 0, 0, DateTimeZone.UTC))
+        generated = Score.builder()
+            .id(BASE_IRI.concat("/terms/201601/courses/7/sections/1/assess/1/users/554433/attempts/1/scores/1"))
+            .attempt(Attempt.builder().id(object.getId()).coercedToId(true).build())
+            .maxScore(15)
+            .scoreGiven(10)
+            .scoredBy(SoftwareApplication.builder().id(BASE_IRI.concat("/autograder")).coercedToId(true).build())
+            .comment("auto-graded exam")
+            .dateCreated(new DateTime(2016, 11, 15, 10, 56, 0, 0, DateTimeZone.UTC))
             .build();
 
         edApp = SoftwareApplication.builder().id(BASE_IRI).coercedToId(true).build();
 
         group = CourseSection.builder()
-            .id(SECTION_IRI)
+            .id(BASE_IRI.concat("/terms/201601/courses/7/sections/1"))
             .courseNumber("CPS 435-01")
-            .academicSession("Fall 2018")
+            .academicSession("Fall 2016")
             .build();
 
-        membership = Membership.builder()
-            .id(BASE_IRI.concat("/terms/201801/courses/7/sections/1/rosters/1"))
-            .member(Person.builder().id(actor.getId()).coercedToId(true).build())
-            .organization(CourseSection.builder().id(SECTION_IRI).coercedToId(true).build())
-            .status(Status.ACTIVE)
-            .role(Role.INSTRUCTOR)
-            .dateCreated(new DateTime(2018, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
-            .build();
-
-        session = Session.builder()
-            .id(BASE_IRI.concat("/sessions/1f6442a482de72ea6ad134943812bff564a76259"))
-            .startedAtTime(new DateTime(2018, 11, 15, 10, 0, 0, 0, DateTimeZone.UTC))
-            .build();
-
-        // Build event
-        event = buildEvent(Profile.RESOURCE_MANAGEMENT, Action.CREATED);
+        // Build Outcome Event
+        event = buildEvent(Profile.GRADING, Action.GRADED);
     }
 
     @Test
@@ -117,13 +107,13 @@ public class ResourceManagementEventCreatedTest {
         ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
         String json = mapper.writeValueAsString(event);
 
-        String fixture = jsonFixture("fixtures/v1p2/caliperEventResourceManagementCreated.json");
+        String fixture = jsonFixture("fixtures/v1p2/caliperEventGradeGraded.json");
         JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Test(expected=IllegalArgumentException.class)
-    public void resourceManagementEventRejectsLaunchedAction() {
-        buildEvent(Profile.SURVEY, Action.LAUNCHED);
+    public void gradeEventRejectsHidAction() {
+        buildEvent(Profile.GRADING, Action.HID);
     }
 
     @After
@@ -132,23 +122,22 @@ public class ResourceManagementEventCreatedTest {
     }
 
     /**
-     * Build ResourceManagementEvent.
+     * Build GradeEvent.
      * @param profile, action
      * @return event
      */
-    private ResourceManagementEvent buildEvent(CaliperProfile profile, CaliperAction action) {
-        return ResourceManagementEvent.builder()
+    private GradeEvent buildEvent(CaliperProfile profile, CaliperAction action) {
+        return GradeEvent.builder()
             .context(context)
-            .profile(profile)
             .id(id)
+            .profile(profile)
             .actor(actor)
             .action(action)
             .object(object)
-            .eventTime(new DateTime(2018, 11, 15, 10, 5, 0, 0, DateTimeZone.UTC))
+            .generated(generated)
             .edApp(edApp)
             .group(group)
-            .membership(membership)
-            .session(session)
+            .eventTime(new DateTime(2016, 11, 15, 10, 57, 6, 0, DateTimeZone.UTC))
             .build();
     }
 }

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/NavigationEventNavigatedToCollectionItemTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/NavigationEventNavigatedToCollectionItemTest.java
@@ -31,10 +31,10 @@ import org.imsglobal.caliper.entities.agent.Person;
 import org.imsglobal.caliper.entities.agent.Role;
 import org.imsglobal.caliper.entities.agent.SoftwareApplication;
 import org.imsglobal.caliper.entities.agent.Status;
-import org.imsglobal.caliper.entities.resource.DigitalResource;
 import org.imsglobal.caliper.entities.resource.DigitalResourceCollection;
+import org.imsglobal.caliper.entities.resource.VideoObject;
 import org.imsglobal.caliper.entities.session.Session;
-import org.imsglobal.caliper.events.ResourceManagementEvent;
+import org.imsglobal.caliper.events.NavigationEvent;
 import org.imsglobal.caliper.profiles.CaliperProfile;
 import org.imsglobal.caliper.profiles.Profile;
 import org.joda.time.DateTime;
@@ -49,67 +49,84 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
 @Category(org.imsglobal.caliper.UnitTest.class)
-public class ResourceManagementEventCreatedTest {
+public class NavigationEventNavigatedToCollectionItemTest {
     private JsonldContext context;
     private String id;
     private Person actor;
-    private CourseSection section;
-    private DigitalResource object;
-    private DigitalResourceCollection collection;
+    private DigitalResourceCollection object;
+    private SoftwareApplication edApp;
     private CourseSection group;
     private Membership membership;
-    private ResourceManagementEvent event;
+    private VideoObject referrer;
+    private VideoObject target;
     private Session session;
-    private SoftwareApplication edApp;
+    private NavigationEvent event;
 
     private static final String BASE_IRI = "https://example.edu";
-    private static final String SECTION_IRI = BASE_IRI.concat("/terms/201801/courses/7/sections/1");
 
     @Before
     public void setUp() throws Exception {
         context = JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value());
-        id = "urn:uuid:0c81f804-62ee-4953-81c5-62d9579c4369";
+
+        DateTime dateCreated = new DateTime(2016, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC);
+
+        id = "urn:uuid:ff9ec22a-fc59-4ae1-ae8d-2c9463ee2f8f";
+
         actor = Person.builder().id(BASE_IRI.concat("/users/554433")).build();
 
-        collection = DigitalResourceCollection.builder()
-            .id(SECTION_IRI.concat("/resources/1"))
-            .name("Course Assets")
-            .isPartOf(CourseSection.builder().id(SECTION_IRI).build())
+        object = DigitalResourceCollection.builder()
+            .id(BASE_IRI.concat("/terms/201601/courses/7/sections/1/resources/2"))
+            .name("Video Collection")
+            .keyword("collection")
+            .keyword("videos")
+            .dateCreated(dateCreated)
+            .dateModified(new DateTime(2016, 9, 2, 11, 30, 0, 0, DateTimeZone.UTC))
             .build();
 
-        object = DigitalResource.builder()
-            .id(SECTION_IRI.concat("/resources/1/syllabus.pdf"))
-            .name("Course Syllabus")
-            .creator(actor)
-            .mediaType("application/pdf")
-            .isPartOf(collection)
-            .dateCreated(new DateTime(2018, 8, 2, 11, 32, 0, 0, DateTimeZone.UTC))
+        referrer = VideoObject.builder()
+            .id(BASE_IRI.concat("/videos/1225"))
+            .mediaType("video/ogg")
+            .name("Introduction to IMS Caliper")
+            .storageName("caliper-intro.ogg")
+            .dateCreated(dateCreated)
+            .duration("PT1H12M27S")
+            .version("1.1")
+            .build();
+
+        target = VideoObject.builder()
+            .id(BASE_IRI.concat("/videos/5629"))
+            .mediaType("video/ogg")
+            .name("IMS Caliper Activity Profiles")
+            .storageName("caliper-activity-profiles.ogg")
+            .dateCreated(dateCreated)
+            .duration("PT55M13S")
+            .version("1.1.1")
             .build();
 
         edApp = SoftwareApplication.builder().id(BASE_IRI).coercedToId(true).build();
 
         group = CourseSection.builder()
-            .id(SECTION_IRI)
+            .id(BASE_IRI.concat("/terms/201601/courses/7/sections/1"))
             .courseNumber("CPS 435-01")
-            .academicSession("Fall 2018")
+            .academicSession("Fall 2016")
             .build();
 
         membership = Membership.builder()
-            .id(BASE_IRI.concat("/terms/201801/courses/7/sections/1/rosters/1"))
+            .id(BASE_IRI.concat("/terms/201601/courses/7/sections/1/rosters/1"))
             .member(Person.builder().id(actor.getId()).coercedToId(true).build())
-            .organization(CourseSection.builder().id(SECTION_IRI).coercedToId(true).build())
+            .organization(CourseSection.builder().id(group.getId()).coercedToId(true).build())
+            .role(Role.LEARNER)
             .status(Status.ACTIVE)
-            .role(Role.INSTRUCTOR)
-            .dateCreated(new DateTime(2018, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
+            .dateCreated(dateCreated)
             .build();
 
         session = Session.builder()
             .id(BASE_IRI.concat("/sessions/1f6442a482de72ea6ad134943812bff564a76259"))
-            .startedAtTime(new DateTime(2018, 11, 15, 10, 0, 0, 0, DateTimeZone.UTC))
+            .startedAtTime(new DateTime(2016, 11, 15, 10, 0, 0, 0, DateTimeZone.UTC))
             .build();
 
         // Build event
-        event = buildEvent(Profile.RESOURCE_MANAGEMENT, Action.CREATED);
+        event = buildEvent(Profile.MEDIA, Action.NAVIGATED_TO);
     }
 
     @Test
@@ -117,13 +134,13 @@ public class ResourceManagementEventCreatedTest {
         ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
         String json = mapper.writeValueAsString(event);
 
-        String fixture = jsonFixture("fixtures/v1p2/caliperEventResourceManagementCreated.json");
+        String fixture = jsonFixture("fixtures/v1p2/caliperEventNavigationNavigatedToCollectionItem.json");
         JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Test(expected=IllegalArgumentException.class)
-    public void resourceManagementEventRejectsLaunchedAction() {
-        buildEvent(Profile.SURVEY, Action.LAUNCHED);
+    public void navigationEventRejectsViewedAction() {
+        buildEvent(Profile.MEDIA, Action.VIEWED);
     }
 
     @After
@@ -132,19 +149,21 @@ public class ResourceManagementEventCreatedTest {
     }
 
     /**
-     * Build ResourceManagementEvent.
+     * Build NavigationEvent.
      * @param profile, action
      * @return event
      */
-    private ResourceManagementEvent buildEvent(CaliperProfile profile, CaliperAction action) {
-        return ResourceManagementEvent.builder()
+    private NavigationEvent buildEvent(CaliperProfile profile, CaliperAction action) {
+        return NavigationEvent.builder()
             .context(context)
-            .profile(profile)
             .id(id)
+            .profile(profile)
             .actor(actor)
             .action(action)
             .object(object)
-            .eventTime(new DateTime(2018, 11, 15, 10, 5, 0, 0, DateTimeZone.UTC))
+            .eventTime(new DateTime(2016, 11, 15, 10, 15, 0, 0, DateTimeZone.UTC))
+            .referrer(referrer)
+            .target(target)
             .edApp(edApp)
             .group(group)
             .membership(membership)

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/NavigationEventNavigatedToCollectionItemTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/NavigationEventNavigatedToCollectionItemTest.java
@@ -19,6 +19,7 @@
 package org.imsglobal.caliper.v1p2.events;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
 import org.imsglobal.caliper.TestUtils;
 import org.imsglobal.caliper.actions.Action;
 import org.imsglobal.caliper.actions.CaliperAction;
@@ -45,6 +46,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import java.util.List;
 
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
@@ -74,10 +77,13 @@ public class NavigationEventNavigatedToCollectionItemTest {
 
         actor = Person.builder().id(BASE_IRI.concat("/users/554433")).build();
 
+        List<String> keywords = Lists.newArrayList();
+        keywords.add("collection");
+
         object = DigitalResourceCollection.builder()
             .id(BASE_IRI.concat("/terms/201601/courses/7/sections/1/resources/2"))
             .name("Video Collection")
-            .keyword("collection")
+            .keywords(keywords)
             .keyword("videos")
             .dateCreated(dateCreated)
             .dateModified(new DateTime(2016, 9, 2, 11, 30, 0, 0, DateTimeZone.UTC))

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/NavigationEventNavigatedToQuestionnaireItemTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/NavigationEventNavigatedToQuestionnaireItemTest.java
@@ -31,10 +31,10 @@ import org.imsglobal.caliper.entities.agent.Person;
 import org.imsglobal.caliper.entities.agent.Role;
 import org.imsglobal.caliper.entities.agent.SoftwareApplication;
 import org.imsglobal.caliper.entities.agent.Status;
-import org.imsglobal.caliper.entities.resource.DigitalResource;
-import org.imsglobal.caliper.entities.resource.DigitalResourceCollection;
+import org.imsglobal.caliper.entities.question.OpenEndedQuestion;
+import org.imsglobal.caliper.entities.resource.QuestionnaireItem;
 import org.imsglobal.caliper.entities.session.Session;
-import org.imsglobal.caliper.events.ResourceManagementEvent;
+import org.imsglobal.caliper.events.NavigationEvent;
 import org.imsglobal.caliper.profiles.CaliperProfile;
 import org.imsglobal.caliper.profiles.Profile;
 import org.joda.time.DateTime;
@@ -46,50 +46,50 @@ import org.junit.experimental.categories.Category;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 
+import java.util.prefs.BackingStoreException;
+
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
 @Category(org.imsglobal.caliper.UnitTest.class)
-public class ResourceManagementEventCreatedTest {
+public class NavigationEventNavigatedToQuestionnaireItemTest {
     private JsonldContext context;
     private String id;
     private Person actor;
-    private CourseSection section;
-    private DigitalResource object;
-    private DigitalResourceCollection collection;
+    private QuestionnaireItem object;
+    private SoftwareApplication edApp;
     private CourseSection group;
     private Membership membership;
-    private ResourceManagementEvent event;
     private Session session;
-    private SoftwareApplication edApp;
+    private NavigationEvent event;
 
     private static final String BASE_IRI = "https://example.edu";
-    private static final String SECTION_IRI = BASE_IRI.concat("/terms/201801/courses/7/sections/1");
 
     @Before
     public void setUp() throws Exception {
         context = JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value());
-        id = "urn:uuid:0c81f804-62ee-4953-81c5-62d9579c4369";
+
+        id = "urn:uuid:a9ea1cb9-3445-4f5a-b5e5-44630cc054a9";
+
         actor = Person.builder().id(BASE_IRI.concat("/users/554433")).build();
 
-        collection = DigitalResourceCollection.builder()
-            .id(SECTION_IRI.concat("/resources/1"))
-            .name("Course Assets")
-            .isPartOf(CourseSection.builder().id(SECTION_IRI).build())
+        OpenEndedQuestion question = OpenEndedQuestion.builder()
+            .id(BASE_IRI.concat("/surveys/100/questionnaires/30/items/2/question"))
+            .questionPosed("What would you change about your course?")
             .build();
 
-        object = DigitalResource.builder()
-            .id(SECTION_IRI.concat("/resources/1/syllabus.pdf"))
-            .name("Course Syllabus")
-            .creator(actor)
-            .mediaType("application/pdf")
-            .isPartOf(collection)
-            .dateCreated(new DateTime(2018, 8, 2, 11, 32, 0, 0, DateTimeZone.UTC))
+        object = QuestionnaireItem.builder()
+            .id(BASE_IRI.concat("/surveys/100/questionnaires/30/items/2"))
+            .question(question)
+            .category("teaching effectiveness")
+            .category("Course structure")
+            .weight(1.0)
             .build();
+
 
         edApp = SoftwareApplication.builder().id(BASE_IRI).coercedToId(true).build();
 
         group = CourseSection.builder()
-            .id(SECTION_IRI)
+            .id(BASE_IRI.concat("/terms/201801/courses/7/sections/1"))
             .courseNumber("CPS 435-01")
             .academicSession("Fall 2018")
             .build();
@@ -97,19 +97,19 @@ public class ResourceManagementEventCreatedTest {
         membership = Membership.builder()
             .id(BASE_IRI.concat("/terms/201801/courses/7/sections/1/rosters/1"))
             .member(Person.builder().id(actor.getId()).coercedToId(true).build())
-            .organization(CourseSection.builder().id(SECTION_IRI).coercedToId(true).build())
+            .organization(CourseSection.builder().id(group.getId()).coercedToId(true).build())
+            .role(Role.LEARNER)
             .status(Status.ACTIVE)
-            .role(Role.INSTRUCTOR)
             .dateCreated(new DateTime(2018, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
             .build();
 
         session = Session.builder()
-            .id(BASE_IRI.concat("/sessions/1f6442a482de72ea6ad134943812bff564a76259"))
-            .startedAtTime(new DateTime(2018, 11, 15, 10, 0, 0, 0, DateTimeZone.UTC))
+            .id(BASE_IRI.concat("/sessions/f095bbd391ea4a5dd639724a40b606e98a631823"))
+            .startedAtTime(new DateTime(2018, 11, 12, 10, 0, 0, 0, DateTimeZone.UTC))
             .build();
 
         // Build event
-        event = buildEvent(Profile.RESOURCE_MANAGEMENT, Action.CREATED);
+        event = buildEvent(Profile.SURVEY, Action.NAVIGATED_TO);
     }
 
     @Test
@@ -117,13 +117,13 @@ public class ResourceManagementEventCreatedTest {
         ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
         String json = mapper.writeValueAsString(event);
 
-        String fixture = jsonFixture("fixtures/v1p2/caliperEventResourceManagementCreated.json");
+        String fixture = jsonFixture("fixtures/v1p2/caliperEventNavigationNavigatedToQuestionnaireItem.json");
         JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Test(expected=IllegalArgumentException.class)
-    public void resourceManagementEventRejectsLaunchedAction() {
-        buildEvent(Profile.SURVEY, Action.LAUNCHED);
+    public void navigationEventRejectsViewedAction() {
+        buildEvent(Profile.SURVEY, Action.VIEWED);
     }
 
     @After
@@ -132,19 +132,19 @@ public class ResourceManagementEventCreatedTest {
     }
 
     /**
-     * Build ResourceManagementEvent.
+     * Build NavigationEvent.
      * @param profile, action
      * @return event
      */
-    private ResourceManagementEvent buildEvent(CaliperProfile profile, CaliperAction action) {
-        return ResourceManagementEvent.builder()
+    private NavigationEvent buildEvent(CaliperProfile profile, CaliperAction action) {
+        return NavigationEvent.builder()
             .context(context)
-            .profile(profile)
             .id(id)
+            .profile(profile)
             .actor(actor)
             .action(action)
             .object(object)
-            .eventTime(new DateTime(2018, 11, 15, 10, 5, 0, 0, DateTimeZone.UTC))
+            .eventTime(new DateTime(2018, 11, 12, 10, 15, 0, 0, DateTimeZone.UTC))
             .edApp(edApp)
             .group(group)
             .membership(membership)

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/NavigationEventNavigatedToQuestionnaireItemTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/NavigationEventNavigatedToQuestionnaireItemTest.java
@@ -46,8 +46,6 @@ import org.junit.experimental.categories.Category;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 
-import java.util.prefs.BackingStoreException;
-
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
 @Category(org.imsglobal.caliper.UnitTest.class)
@@ -84,7 +82,6 @@ public class NavigationEventNavigatedToQuestionnaireItemTest {
             .category("Course structure")
             .weight(1.0)
             .build();
-
 
         edApp = SoftwareApplication.builder().id(BASE_IRI).coercedToId(true).build();
 

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/NavigationEventNavigatedToWebPageTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/NavigationEventNavigatedToWebPageTest.java
@@ -31,10 +31,9 @@ import org.imsglobal.caliper.entities.agent.Person;
 import org.imsglobal.caliper.entities.agent.Role;
 import org.imsglobal.caliper.entities.agent.SoftwareApplication;
 import org.imsglobal.caliper.entities.agent.Status;
-import org.imsglobal.caliper.entities.resource.DigitalResource;
-import org.imsglobal.caliper.entities.resource.DigitalResourceCollection;
+import org.imsglobal.caliper.entities.resource.WebPage;
 import org.imsglobal.caliper.entities.session.Session;
-import org.imsglobal.caliper.events.ResourceManagementEvent;
+import org.imsglobal.caliper.events.NavigationEvent;
 import org.imsglobal.caliper.profiles.CaliperProfile;
 import org.imsglobal.caliper.profiles.Profile;
 import org.joda.time.DateTime;
@@ -49,67 +48,61 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
 @Category(org.imsglobal.caliper.UnitTest.class)
-public class ResourceManagementEventCreatedTest {
+public class NavigationEventNavigatedToWebPageTest {
     private JsonldContext context;
     private String id;
     private Person actor;
-    private CourseSection section;
-    private DigitalResource object;
-    private DigitalResourceCollection collection;
+    private WebPage object;
+    private SoftwareApplication edApp;
     private CourseSection group;
     private Membership membership;
-    private ResourceManagementEvent event;
+    private WebPage referrer;
     private Session session;
-    private SoftwareApplication edApp;
+    private NavigationEvent event;
 
     private static final String BASE_IRI = "https://example.edu";
-    private static final String SECTION_IRI = BASE_IRI.concat("/terms/201801/courses/7/sections/1");
 
     @Before
     public void setUp() throws Exception {
         context = JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value());
-        id = "urn:uuid:0c81f804-62ee-4953-81c5-62d9579c4369";
+
+        id = "urn:uuid:ff9ec22a-fc59-4ae1-ae8d-2c9463ee2f8f";
+
         actor = Person.builder().id(BASE_IRI.concat("/users/554433")).build();
 
-        collection = DigitalResourceCollection.builder()
-            .id(SECTION_IRI.concat("/resources/1"))
-            .name("Course Assets")
-            .isPartOf(CourseSection.builder().id(SECTION_IRI).build())
+        object = WebPage.builder()
+            .id(BASE_IRI.concat("/terms/201601/courses/7/sections/1/pages/2"))
+            .name("Learning Analytics Specifications")
+            .description("Overview of Learning Analytics Specifications with particular emphasis on IMS Caliper.")
+            .dateCreated(new DateTime(2016, 8, 1, 9, 0, 0, 0, DateTimeZone.UTC))
             .build();
 
-        object = DigitalResource.builder()
-            .id(SECTION_IRI.concat("/resources/1/syllabus.pdf"))
-            .name("Course Syllabus")
-            .creator(actor)
-            .mediaType("application/pdf")
-            .isPartOf(collection)
-            .dateCreated(new DateTime(2018, 8, 2, 11, 32, 0, 0, DateTimeZone.UTC))
-            .build();
+        referrer = WebPage.builder().id(BASE_IRI.concat("/terms/201601/courses/7/sections/1/pages/1")).build();
 
         edApp = SoftwareApplication.builder().id(BASE_IRI).coercedToId(true).build();
 
         group = CourseSection.builder()
-            .id(SECTION_IRI)
+            .id(BASE_IRI.concat("/terms/201601/courses/7/sections/1"))
             .courseNumber("CPS 435-01")
-            .academicSession("Fall 2018")
+            .academicSession("Fall 2016")
             .build();
 
         membership = Membership.builder()
-            .id(BASE_IRI.concat("/terms/201801/courses/7/sections/1/rosters/1"))
+            .id(BASE_IRI.concat("/terms/201601/courses/7/sections/1/rosters/1"))
             .member(Person.builder().id(actor.getId()).coercedToId(true).build())
-            .organization(CourseSection.builder().id(SECTION_IRI).coercedToId(true).build())
+            .organization(CourseSection.builder().id(group.getId()).coercedToId(true).build())
             .status(Status.ACTIVE)
-            .role(Role.INSTRUCTOR)
-            .dateCreated(new DateTime(2018, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
+            .role(Role.LEARNER)
+            .dateCreated(new DateTime(2016, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
             .build();
 
         session = Session.builder()
             .id(BASE_IRI.concat("/sessions/1f6442a482de72ea6ad134943812bff564a76259"))
-            .startedAtTime(new DateTime(2018, 11, 15, 10, 0, 0, 0, DateTimeZone.UTC))
+            .startedAtTime(new DateTime(2016, 11, 15, 10, 0, 0, 0, DateTimeZone.UTC))
             .build();
 
         // Build event
-        event = buildEvent(Profile.RESOURCE_MANAGEMENT, Action.CREATED);
+        event = buildEvent(Profile.READING, Action.NAVIGATED_TO);
     }
 
     @Test
@@ -117,13 +110,13 @@ public class ResourceManagementEventCreatedTest {
         ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
         String json = mapper.writeValueAsString(event);
 
-        String fixture = jsonFixture("fixtures/v1p2/caliperEventResourceManagementCreated.json");
+        String fixture = jsonFixture("fixtures/v1p2/caliperEventNavigationNavigatedToWebPage.json");
         JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Test(expected=IllegalArgumentException.class)
-    public void resourceManagementEventRejectsLaunchedAction() {
-        buildEvent(Profile.SURVEY, Action.LAUNCHED);
+    public void navigationEventRejectsViewedAction() {
+        buildEvent(Profile.READING, Action.VIEWED);
     }
 
     @After
@@ -132,19 +125,20 @@ public class ResourceManagementEventCreatedTest {
     }
 
     /**
-     * Build ResourceManagementEvent.
+     * Build NavigationEvent.
      * @param profile, action
      * @return event
      */
-    private ResourceManagementEvent buildEvent(CaliperProfile profile, CaliperAction action) {
-        return ResourceManagementEvent.builder()
+    private NavigationEvent buildEvent(CaliperProfile profile, CaliperAction action) {
+        return NavigationEvent.builder()
             .context(context)
-            .profile(profile)
             .id(id)
+            .profile(profile)
             .actor(actor)
             .action(action)
             .object(object)
-            .eventTime(new DateTime(2018, 11, 15, 10, 5, 0, 0, DateTimeZone.UTC))
+            .eventTime(new DateTime(2016, 11, 15, 10, 15, 0, 0, DateTimeZone.UTC))
+            .referrer(referrer)
             .edApp(edApp)
             .group(group)
             .membership(membership)

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/NavigationEventNavigatedToWebPageThinnedTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/NavigationEventNavigatedToWebPageThinnedTest.java
@@ -28,13 +28,10 @@ import org.imsglobal.caliper.context.JsonldStringContext;
 import org.imsglobal.caliper.entities.agent.CourseSection;
 import org.imsglobal.caliper.entities.agent.Membership;
 import org.imsglobal.caliper.entities.agent.Person;
-import org.imsglobal.caliper.entities.agent.Role;
 import org.imsglobal.caliper.entities.agent.SoftwareApplication;
-import org.imsglobal.caliper.entities.agent.Status;
-import org.imsglobal.caliper.entities.resource.DigitalResource;
-import org.imsglobal.caliper.entities.resource.DigitalResourceCollection;
+import org.imsglobal.caliper.entities.resource.WebPage;
 import org.imsglobal.caliper.entities.session.Session;
-import org.imsglobal.caliper.events.ResourceManagementEvent;
+import org.imsglobal.caliper.events.NavigationEvent;
 import org.imsglobal.caliper.profiles.CaliperProfile;
 import org.imsglobal.caliper.profiles.Profile;
 import org.joda.time.DateTime;
@@ -49,67 +46,55 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
 @Category(org.imsglobal.caliper.UnitTest.class)
-public class ResourceManagementEventCreatedTest {
+public class NavigationEventNavigatedToWebPageThinnedTest {
     private JsonldContext context;
     private String id;
     private Person actor;
-    private CourseSection section;
-    private DigitalResource object;
-    private DigitalResourceCollection collection;
+    private WebPage object;
+    private SoftwareApplication edApp;
     private CourseSection group;
     private Membership membership;
-    private ResourceManagementEvent event;
+    private WebPage referrer;
     private Session session;
-    private SoftwareApplication edApp;
+    private NavigationEvent event;
 
     private static final String BASE_IRI = "https://example.edu";
-    private static final String SECTION_IRI = BASE_IRI.concat("/terms/201801/courses/7/sections/1");
+    private static final String SECTION_IRI = BASE_IRI.concat("/terms/201601/courses/7/sections/1");
 
     @Before
     public void setUp() throws Exception {
         context = JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value());
-        id = "urn:uuid:0c81f804-62ee-4953-81c5-62d9579c4369";
-        actor = Person.builder().id(BASE_IRI.concat("/users/554433")).build();
 
-        collection = DigitalResourceCollection.builder()
-            .id(SECTION_IRI.concat("/resources/1"))
-            .name("Course Assets")
-            .isPartOf(CourseSection.builder().id(SECTION_IRI).build())
+        id = "urn:uuid:71657137-8e6e-44f8-8499-e1c3df6810d2";
+
+        actor = Person.builder().id(BASE_IRI.concat("/users/554433")).coercedToId(true).build();
+
+        object = WebPage.builder()
+            .id(SECTION_IRI.concat("/pages/2"))
+            .coercedToId(true)
             .build();
 
-        object = DigitalResource.builder()
-            .id(SECTION_IRI.concat("/resources/1/syllabus.pdf"))
-            .name("Course Syllabus")
-            .creator(actor)
-            .mediaType("application/pdf")
-            .isPartOf(collection)
-            .dateCreated(new DateTime(2018, 8, 2, 11, 32, 0, 0, DateTimeZone.UTC))
+        referrer = WebPage.builder()
+            .id(SECTION_IRI.concat("/pages/1"))
+            .coercedToId(true)
             .build();
 
         edApp = SoftwareApplication.builder().id(BASE_IRI).coercedToId(true).build();
 
-        group = CourseSection.builder()
-            .id(SECTION_IRI)
-            .courseNumber("CPS 435-01")
-            .academicSession("Fall 2018")
-            .build();
+        group = CourseSection.builder().id(SECTION_IRI).coercedToId(true).build();
 
         membership = Membership.builder()
-            .id(BASE_IRI.concat("/terms/201801/courses/7/sections/1/rosters/1"))
-            .member(Person.builder().id(actor.getId()).coercedToId(true).build())
-            .organization(CourseSection.builder().id(SECTION_IRI).coercedToId(true).build())
-            .status(Status.ACTIVE)
-            .role(Role.INSTRUCTOR)
-            .dateCreated(new DateTime(2018, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
+            .id(SECTION_IRI.concat("/rosters/1"))
+            .coercedToId(true)
             .build();
 
         session = Session.builder()
             .id(BASE_IRI.concat("/sessions/1f6442a482de72ea6ad134943812bff564a76259"))
-            .startedAtTime(new DateTime(2018, 11, 15, 10, 0, 0, 0, DateTimeZone.UTC))
+            .coercedToId(true)
             .build();
 
         // Build event
-        event = buildEvent(Profile.RESOURCE_MANAGEMENT, Action.CREATED);
+        event = buildEvent(Profile.READING, Action.NAVIGATED_TO);
     }
 
     @Test
@@ -117,13 +102,13 @@ public class ResourceManagementEventCreatedTest {
         ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
         String json = mapper.writeValueAsString(event);
 
-        String fixture = jsonFixture("fixtures/v1p2/caliperEventResourceManagementCreated.json");
+        String fixture = jsonFixture("fixtures/v1p2/caliperEventNavigationNavigatedToWebPageThinned.json");
         JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Test(expected=IllegalArgumentException.class)
-    public void resourceManagementEventRejectsLaunchedAction() {
-        buildEvent(Profile.SURVEY, Action.LAUNCHED);
+    public void navigationEventRejectsViewedAction() {
+        buildEvent(Profile.READING, Action.VIEWED);
     }
 
     @After
@@ -132,19 +117,20 @@ public class ResourceManagementEventCreatedTest {
     }
 
     /**
-     * Build ResourceManagementEvent.
+     * Build NavigationEvent.
      * @param profile, action
      * @return event
      */
-    private ResourceManagementEvent buildEvent(CaliperProfile profile, CaliperAction action) {
-        return ResourceManagementEvent.builder()
+    private NavigationEvent buildEvent(CaliperProfile profile, CaliperAction action) {
+        return NavigationEvent.builder()
             .context(context)
-            .profile(profile)
             .id(id)
+            .profile(profile)
             .actor(actor)
             .action(action)
             .object(object)
-            .eventTime(new DateTime(2018, 11, 15, 10, 5, 0, 0, DateTimeZone.UTC))
+            .eventTime(new DateTime(2016, 11, 15, 10, 15, 0, 0, DateTimeZone.UTC))
+            .referrer(referrer)
             .edApp(edApp)
             .group(group)
             .membership(membership)

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/QuestionnaireEventStartedTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/QuestionnaireEventStartedTest.java
@@ -19,6 +19,7 @@
 package org.imsglobal.caliper.v1p2.events;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
 import org.imsglobal.caliper.TestUtils;
 import org.imsglobal.caliper.actions.Action;
 import org.imsglobal.caliper.actions.CaliperAction;
@@ -45,6 +46,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import java.util.List;
 
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
@@ -77,9 +80,12 @@ public class QuestionnaireEventStartedTest {
             .id(BASE_IRI.concat("/surveys/100/questionnaires/30/items/2"))
             .build();
 
+        List<QuestionnaireItem> items = Lists.newArrayList();
+        items.add(itemOne);
+
         object = Questionnaire.builder()
             .id(BASE_IRI.concat("/surveys/100/questionnaires/30"))
-            .item(itemOne)
+            .items(items)
             .item(itemTwo)
             .dateCreated(new DateTime(2018, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
             .build();

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/QuestionnaireEventSubmittedTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/QuestionnaireEventSubmittedTest.java
@@ -31,10 +31,10 @@ import org.imsglobal.caliper.entities.agent.Person;
 import org.imsglobal.caliper.entities.agent.Role;
 import org.imsglobal.caliper.entities.agent.SoftwareApplication;
 import org.imsglobal.caliper.entities.agent.Status;
-import org.imsglobal.caliper.entities.resource.DigitalResource;
-import org.imsglobal.caliper.entities.resource.DigitalResourceCollection;
+import org.imsglobal.caliper.entities.resource.Questionnaire;
+import org.imsglobal.caliper.entities.resource.QuestionnaireItem;
 import org.imsglobal.caliper.entities.session.Session;
-import org.imsglobal.caliper.events.ResourceManagementEvent;
+import org.imsglobal.caliper.events.QuestionnaireEvent;
 import org.imsglobal.caliper.profiles.CaliperProfile;
 import org.imsglobal.caliper.profiles.Profile;
 import org.joda.time.DateTime;
@@ -49,18 +49,16 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
 @Category(org.imsglobal.caliper.UnitTest.class)
-public class ResourceManagementEventCreatedTest {
+public class QuestionnaireEventSubmittedTest {
     private JsonldContext context;
     private String id;
     private Person actor;
-    private CourseSection section;
-    private DigitalResource object;
-    private DigitalResourceCollection collection;
+    private Questionnaire object;
     private CourseSection group;
-    private Membership membership;
-    private ResourceManagementEvent event;
-    private Session session;
     private SoftwareApplication edApp;
+    private Membership membership;
+    private Session session;
+    private QuestionnaireEvent event;
 
     private static final String BASE_IRI = "https://example.edu";
     private static final String SECTION_IRI = BASE_IRI.concat("/terms/201801/courses/7/sections/1");
@@ -68,25 +66,23 @@ public class ResourceManagementEventCreatedTest {
     @Before
     public void setUp() throws Exception {
         context = JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value());
-        id = "urn:uuid:0c81f804-62ee-4953-81c5-62d9579c4369";
+        id = "urn:uuid:79f18ac2-3c6b-11e9-b210-d663bd873d93";
         actor = Person.builder().id(BASE_IRI.concat("/users/554433")).build();
 
-        collection = DigitalResourceCollection.builder()
-            .id(SECTION_IRI.concat("/resources/1"))
-            .name("Course Assets")
-            .isPartOf(CourseSection.builder().id(SECTION_IRI).build())
+        QuestionnaireItem itemOne = QuestionnaireItem.builder()
+            .id(BASE_IRI.concat("/surveys/100/questionnaires/30/items/1"))
             .build();
 
-        object = DigitalResource.builder()
-            .id(SECTION_IRI.concat("/resources/1/syllabus.pdf"))
-            .name("Course Syllabus")
-            .creator(actor)
-            .mediaType("application/pdf")
-            .isPartOf(collection)
-            .dateCreated(new DateTime(2018, 8, 2, 11, 32, 0, 0, DateTimeZone.UTC))
+        QuestionnaireItem itemTwo = QuestionnaireItem.builder()
+            .id(BASE_IRI.concat("/surveys/100/questionnaires/30/items/2"))
             .build();
 
-        edApp = SoftwareApplication.builder().id(BASE_IRI).coercedToId(true).build();
+        object = Questionnaire.builder()
+            .id(BASE_IRI.concat("/surveys/100/questionnaires/30"))
+            .item(itemOne)
+            .item(itemTwo)
+            .dateCreated(new DateTime(2018, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
+            .build();
 
         group = CourseSection.builder()
             .id(SECTION_IRI)
@@ -95,21 +91,23 @@ public class ResourceManagementEventCreatedTest {
             .build();
 
         membership = Membership.builder()
-            .id(BASE_IRI.concat("/terms/201801/courses/7/sections/1/rosters/1"))
-            .member(Person.builder().id(actor.getId()).coercedToId(true).build())
+            .id(SECTION_IRI.concat("/rosters/1"))
+            .role(Role.LEARNER)
+            .member(Person.builder().id(BASE_IRI.concat("/users/554433")).coercedToId(true).build())
             .organization(CourseSection.builder().id(SECTION_IRI).coercedToId(true).build())
             .status(Status.ACTIVE)
-            .role(Role.INSTRUCTOR)
             .dateCreated(new DateTime(2018, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
             .build();
 
         session = Session.builder()
-            .id(BASE_IRI.concat("/sessions/1f6442a482de72ea6ad134943812bff564a76259"))
-            .startedAtTime(new DateTime(2018, 11, 15, 10, 0, 0, 0, DateTimeZone.UTC))
+            .id(BASE_IRI.concat("/sessions/f095bbd391ea4a5dd639724a40b606e98a631823"))
+            .startedAtTime(new DateTime(2018, 11, 12, 10, 0, 0, 0, DateTimeZone.UTC))
             .build();
 
+        edApp = SoftwareApplication.builder().id(BASE_IRI).coercedToId(true).build();
+
         // Build event
-        event = buildEvent(Profile.RESOURCE_MANAGEMENT, Action.CREATED);
+        event = buildEvent(Profile.SURVEY, Action.SUBMITTED);
     }
 
     @Test
@@ -117,13 +115,13 @@ public class ResourceManagementEventCreatedTest {
         ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
         String json = mapper.writeValueAsString(event);
 
-        String fixture = jsonFixture("fixtures/v1p2/caliperEventResourceManagementCreated.json");
+        String fixture = jsonFixture("fixtures/v1p2/caliperEventQuestionnaireSubmitted.json");
         JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Test(expected=IllegalArgumentException.class)
-    public void resourceManagementEventRejectsLaunchedAction() {
-        buildEvent(Profile.SURVEY, Action.LAUNCHED);
+    public void questionnaireEventRejectsCommentedAction() {
+        buildEvent(Profile.SURVEY, Action.COMMENTED);
     }
 
     @After
@@ -132,19 +130,19 @@ public class ResourceManagementEventCreatedTest {
     }
 
     /**
-     * Build ResourceManagementEvent.
+     * Build QuestionnaireEvent.
      * @param profile, action
      * @return event
      */
-    private ResourceManagementEvent buildEvent(CaliperProfile profile, CaliperAction action) {
-        return ResourceManagementEvent.builder()
+    private QuestionnaireEvent buildEvent(CaliperProfile profile, CaliperAction action) {
+        return QuestionnaireEvent.builder()
             .context(context)
-            .profile(profile)
             .id(id)
+            .profile(profile)
             .actor(actor)
             .action(action)
             .object(object)
-            .eventTime(new DateTime(2018, 11, 15, 10, 5, 0, 0, DateTimeZone.UTC))
+            .eventTime(new DateTime(2018, 11, 12, 10, 15, 0, 0, DateTimeZone.UTC))
             .edApp(edApp)
             .group(group)
             .membership(membership)

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/QuestionnaireEventSubmittedTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/QuestionnaireEventSubmittedTest.java
@@ -19,6 +19,7 @@
 package org.imsglobal.caliper.v1p2.events;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
 import org.imsglobal.caliper.TestUtils;
 import org.imsglobal.caliper.actions.Action;
 import org.imsglobal.caliper.actions.CaliperAction;
@@ -45,6 +46,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import java.util.List;
 
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
@@ -77,9 +80,12 @@ public class QuestionnaireEventSubmittedTest {
             .id(BASE_IRI.concat("/surveys/100/questionnaires/30/items/2"))
             .build();
 
+        List<QuestionnaireItem> items = Lists.newArrayList();
+        items.add(itemOne);
+
         object = Questionnaire.builder()
             .id(BASE_IRI.concat("/surveys/100/questionnaires/30"))
-            .item(itemOne)
+            .items(items)
             .item(itemTwo)
             .dateCreated(new DateTime(2018, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
             .build();

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/QuestionnaireItemEventCompletedOpenEndedQuestionTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/QuestionnaireItemEventCompletedOpenEndedQuestionTest.java
@@ -19,6 +19,7 @@
 package org.imsglobal.caliper.v1p2.events;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
 import org.imsglobal.caliper.TestUtils;
 import org.imsglobal.caliper.actions.Action;
 import org.imsglobal.caliper.actions.CaliperAction;
@@ -46,6 +47,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import java.util.List;
 
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
@@ -77,10 +80,13 @@ public class QuestionnaireItemEventCompletedOpenEndedQuestionTest {
             .questionPosed("What would you change about your course?")
             .build();
 
+        List<String> categories = Lists.newArrayList();
+        categories.add("teaching effectiveness");
+
         object = QuestionnaireItem.builder()
             .id(ITEM_IRI)
             .question(question)
-            .category("teaching effectiveness")
+            .categories(categories)
             .category("Course structure")
             .weight(1.0)
             .build();
@@ -112,9 +118,9 @@ public class QuestionnaireItemEventCompletedOpenEndedQuestionTest {
             .build();
 
         session = Session.builder()
-                .id(BASE_IRI.concat("/sessions/f095bbd391ea4a5dd639724a40b606e98a631823"))
-                .startedAtTime(new DateTime(2018, 11, 12, 10, 0, 0, 0, DateTimeZone.UTC))
-                .build();
+            .id(BASE_IRI.concat("/sessions/f095bbd391ea4a5dd639724a40b606e98a631823"))
+            .startedAtTime(new DateTime(2018, 11, 12, 10, 0, 0, 0, DateTimeZone.UTC))
+            .build();
 
         // Build event
         event = buildEvent(Profile.SURVEY, Action.COMPLETED);

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/QuestionnaireItemEventCompletedOpenEndedQuestionTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/QuestionnaireItemEventCompletedOpenEndedQuestionTest.java
@@ -19,7 +19,6 @@
 package org.imsglobal.caliper.v1p2.events;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.Lists;
 import org.imsglobal.caliper.TestUtils;
 import org.imsglobal.caliper.actions.Action;
 import org.imsglobal.caliper.actions.CaliperAction;
@@ -48,8 +47,6 @@ import org.junit.experimental.categories.Category;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 
-import java.util.List;
-
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
 @Category(org.imsglobal.caliper.UnitTest.class)
@@ -75,10 +72,6 @@ public class QuestionnaireItemEventCompletedOpenEndedQuestionTest {
         id = "urn:uuid:590f1ff2-3c6d-11e9-b210-d663bd873d93";
         actor = Person.builder().id(BASE_IRI.concat("/users/554433")).build();
 
-        List<String> categories = Lists.newArrayList();
-        categories.add("teaching effectiveness");
-        categories.add("Course structure");
-
         OpenEndedQuestion question = OpenEndedQuestion.builder()
             .id(ITEM_IRI.concat("/question"))
             .questionPosed("What would you change about your course?")
@@ -87,7 +80,8 @@ public class QuestionnaireItemEventCompletedOpenEndedQuestionTest {
         object = QuestionnaireItem.builder()
             .id(ITEM_IRI)
             .question(question)
-            .categories(categories)
+            .category("teaching effectiveness")
+            .category("Course structure")
             .weight(1.0)
             .build();
 
@@ -108,12 +102,9 @@ public class QuestionnaireItemEventCompletedOpenEndedQuestionTest {
             .academicSession("Fall 2018")
             .build();
 
-        List<Role> roles = Lists.newArrayList();
-        roles.add(Role.LEARNER);
-
         membership = Membership.builder()
             .id(SECTION_IRI.concat("/rosters/1"))
-            .roles(roles)
+            .role(Role.LEARNER)
             .member(Person.builder().id(BASE_IRI.concat("/users/554433")).coercedToId(true).build())
             .organization(CourseSection.builder().id(SECTION_IRI).coercedToId(true).build())
             .status(Status.ACTIVE)
@@ -136,6 +127,11 @@ public class QuestionnaireItemEventCompletedOpenEndedQuestionTest {
 
         String fixture = jsonFixture("fixtures/v1p2/caliperEventQuestionnaireItemCompletedOpenEndedQuestion.json");
         JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void questionnaireItemEventRejectsTimedOutAction() {
+        buildEvent(Profile.SURVEY, Action.TIMED_OUT);
     }
 
     @After

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/QuestionnaireItemEventCompletedRatingScaleQuestionTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/QuestionnaireItemEventCompletedRatingScaleQuestionTest.java
@@ -31,10 +31,12 @@ import org.imsglobal.caliper.entities.agent.Person;
 import org.imsglobal.caliper.entities.agent.Role;
 import org.imsglobal.caliper.entities.agent.SoftwareApplication;
 import org.imsglobal.caliper.entities.agent.Status;
-import org.imsglobal.caliper.entities.resource.DigitalResource;
-import org.imsglobal.caliper.entities.resource.DigitalResourceCollection;
+import org.imsglobal.caliper.entities.question.RatingScaleQuestion;
+import org.imsglobal.caliper.entities.resource.QuestionnaireItem;
+import org.imsglobal.caliper.entities.response.RatingScaleResponse;
+import org.imsglobal.caliper.entities.scale.LikertScale;
 import org.imsglobal.caliper.entities.session.Session;
-import org.imsglobal.caliper.events.ResourceManagementEvent;
+import org.imsglobal.caliper.events.QuestionnaireItemEvent;
 import org.imsglobal.caliper.profiles.CaliperProfile;
 import org.imsglobal.caliper.profiles.Profile;
 import org.joda.time.DateTime;
@@ -49,41 +51,62 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
 @Category(org.imsglobal.caliper.UnitTest.class)
-public class ResourceManagementEventCreatedTest {
+public class QuestionnaireItemEventCompletedRatingScaleQuestionTest {
     private JsonldContext context;
     private String id;
     private Person actor;
-    private CourseSection section;
-    private DigitalResource object;
-    private DigitalResourceCollection collection;
+    private QuestionnaireItem object;
+    private RatingScaleResponse generated;
+    private SoftwareApplication edApp;
     private CourseSection group;
     private Membership membership;
-    private ResourceManagementEvent event;
     private Session session;
-    private SoftwareApplication edApp;
+    private QuestionnaireItemEvent event;
 
     private static final String BASE_IRI = "https://example.edu";
+    private static final String ITEM_IRI = BASE_IRI.concat("/surveys/100/questionnaires/30/items/1");
     private static final String SECTION_IRI = BASE_IRI.concat("/terms/201801/courses/7/sections/1");
 
     @Before
     public void setUp() throws Exception {
         context = JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value());
-        id = "urn:uuid:0c81f804-62ee-4953-81c5-62d9579c4369";
+        id = "urn:uuid:590f1ff2-3c6d-11e9-b210-d663bd873d93";
         actor = Person.builder().id(BASE_IRI.concat("/users/554433")).build();
 
-        collection = DigitalResourceCollection.builder()
-            .id(SECTION_IRI.concat("/resources/1"))
-            .name("Course Assets")
-            .isPartOf(CourseSection.builder().id(SECTION_IRI).build())
+        LikertScale scale = LikertScale.builder()
+            .id(BASE_IRI.concat("/scale/2"))
+            .scalePoints(4)
+            .itemLabel("Strongly Disagree")
+            .itemLabel("Disagree")
+            .itemLabel("Agree")
+            .itemLabel("Strongly Agree")
+            .itemValue("-2")
+            .itemValue("-1")
+            .itemValue("1")
+            .itemValue("2")
             .build();
 
-        object = DigitalResource.builder()
-            .id(SECTION_IRI.concat("/resources/1/syllabus.pdf"))
-            .name("Course Syllabus")
-            .creator(actor)
-            .mediaType("application/pdf")
-            .isPartOf(collection)
-            .dateCreated(new DateTime(2018, 8, 2, 11, 32, 0, 0, DateTimeZone.UTC))
+        RatingScaleQuestion question = RatingScaleQuestion.builder()
+            .id(ITEM_IRI.concat("/question"))
+            .questionPosed("How satisfied are you with our services?")
+            .scale(scale)
+            .build();
+
+        object = QuestionnaireItem.builder()
+            .id(ITEM_IRI)
+            .question(question)
+            .category("teaching effectiveness")
+            .category("Course structure")
+            .weight(1.0)
+            .build();
+
+        generated = RatingScaleResponse.builder()
+            .id(ITEM_IRI.concat("/users/554433/responses/1"))
+            .selection("Satisfied")
+            .startedAtTime(new DateTime(2018, 8, 1, 5, 55, 48, 0, DateTimeZone.UTC))
+            .endedAtTime(new DateTime(2018, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
+            .duration("PT4M12S")
+            .dateCreated(new DateTime(2018, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
             .build();
 
         edApp = SoftwareApplication.builder().id(BASE_IRI).coercedToId(true).build();
@@ -95,21 +118,21 @@ public class ResourceManagementEventCreatedTest {
             .build();
 
         membership = Membership.builder()
-            .id(BASE_IRI.concat("/terms/201801/courses/7/sections/1/rosters/1"))
-            .member(Person.builder().id(actor.getId()).coercedToId(true).build())
+            .id(SECTION_IRI.concat("/rosters/1"))
+            .role(Role.LEARNER)
+            .member(Person.builder().id(BASE_IRI.concat("/users/554433")).coercedToId(true).build())
             .organization(CourseSection.builder().id(SECTION_IRI).coercedToId(true).build())
             .status(Status.ACTIVE)
-            .role(Role.INSTRUCTOR)
             .dateCreated(new DateTime(2018, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
             .build();
 
         session = Session.builder()
-            .id(BASE_IRI.concat("/sessions/1f6442a482de72ea6ad134943812bff564a76259"))
-            .startedAtTime(new DateTime(2018, 11, 15, 10, 0, 0, 0, DateTimeZone.UTC))
+            .id(BASE_IRI.concat("/sessions/f095bbd391ea4a5dd639724a40b606e98a631823"))
+            .startedAtTime(new DateTime(2018, 11, 12, 10, 0, 0, 0, DateTimeZone.UTC))
             .build();
 
         // Build event
-        event = buildEvent(Profile.RESOURCE_MANAGEMENT, Action.CREATED);
+        event = buildEvent(Profile.SURVEY, Action.COMPLETED);
     }
 
     @Test
@@ -117,13 +140,13 @@ public class ResourceManagementEventCreatedTest {
         ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
         String json = mapper.writeValueAsString(event);
 
-        String fixture = jsonFixture("fixtures/v1p2/caliperEventResourceManagementCreated.json");
+        String fixture = jsonFixture("fixtures/v1p2/caliperEventQuestionnaireItemCompletedRatingScaleQuestion.json");
         JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Test(expected=IllegalArgumentException.class)
-    public void resourceManagementEventRejectsLaunchedAction() {
-        buildEvent(Profile.SURVEY, Action.LAUNCHED);
+    public void questionnaireItemEventRejectsTimedOutAction() {
+        buildEvent(Profile.SURVEY, Action.TIMED_OUT);
     }
 
     @After
@@ -132,19 +155,20 @@ public class ResourceManagementEventCreatedTest {
     }
 
     /**
-     * Build ResourceManagementEvent.
+     * Build QuestionnaireItemEvent.
      * @param profile, action
      * @return event
      */
-    private ResourceManagementEvent buildEvent(CaliperProfile profile, CaliperAction action) {
-        return ResourceManagementEvent.builder()
+    private QuestionnaireItemEvent buildEvent(CaliperProfile profile, CaliperAction action) {
+        return QuestionnaireItemEvent.builder()
             .context(context)
-            .profile(profile)
             .id(id)
+            .profile(profile)
             .actor(actor)
             .action(action)
             .object(object)
-            .eventTime(new DateTime(2018, 11, 15, 10, 5, 0, 0, DateTimeZone.UTC))
+            .generated(generated)
+            .eventTime(new DateTime(2018, 11, 12, 10, 15, 0, 0, DateTimeZone.UTC))
             .edApp(edApp)
             .group(group)
             .membership(membership)

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/QuestionnaireItemEventCompletedRatingScaleQuestionTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/QuestionnaireItemEventCompletedRatingScaleQuestionTest.java
@@ -19,6 +19,7 @@
 package org.imsglobal.caliper.v1p2.events;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
 import org.imsglobal.caliper.TestUtils;
 import org.imsglobal.caliper.actions.Action;
 import org.imsglobal.caliper.actions.CaliperAction;
@@ -48,6 +49,8 @@ import org.junit.experimental.categories.Category;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 
+import java.util.List;
+
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
 @Category(org.imsglobal.caliper.UnitTest.class)
@@ -73,16 +76,22 @@ public class QuestionnaireItemEventCompletedRatingScaleQuestionTest {
         id = "urn:uuid:590f1ff2-3c6d-11e9-b210-d663bd873d93";
         actor = Person.builder().id(BASE_IRI.concat("/users/554433")).build();
 
+        List<String> itemLabels = Lists.newArrayList();
+        itemLabels.add("Strongly Disagree");
+        itemLabels.add("Disagree");
+        itemLabels.add("Agree");
+
+        List<String> itemValues = Lists.newArrayList();
+        itemValues.add("-2");
+        itemValues.add("-1");
+        itemValues.add("1");
+
         LikertScale scale = LikertScale.builder()
             .id(BASE_IRI.concat("/scale/2"))
             .scalePoints(4)
-            .itemLabel("Strongly Disagree")
-            .itemLabel("Disagree")
-            .itemLabel("Agree")
+            .itemLabels(itemLabels)
             .itemLabel("Strongly Agree")
-            .itemValue("-2")
-            .itemValue("-1")
-            .itemValue("1")
+            .itemValues(itemValues)
             .itemValue("2")
             .build();
 
@@ -92,10 +101,13 @@ public class QuestionnaireItemEventCompletedRatingScaleQuestionTest {
             .scale(scale)
             .build();
 
+        List<String> categories = Lists.newArrayList();
+        categories.add("teaching effectiveness");
+
         object = QuestionnaireItem.builder()
             .id(ITEM_IRI)
             .question(question)
-            .category("teaching effectiveness")
+            .categories(categories)
             .category("Course structure")
             .weight(1.0)
             .build();

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/QuestionnaireItemEventStartedTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/QuestionnaireItemEventStartedTest.java
@@ -19,6 +19,7 @@
 package org.imsglobal.caliper.v1p2.events;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
 import org.imsglobal.caliper.TestUtils;
 import org.imsglobal.caliper.actions.Action;
 import org.imsglobal.caliper.actions.CaliperAction;
@@ -47,6 +48,8 @@ import org.junit.experimental.categories.Category;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 
+import java.util.List;
+
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
 @Category(org.imsglobal.caliper.UnitTest.class)
@@ -71,16 +74,22 @@ public class QuestionnaireItemEventStartedTest {
         id = "urn:uuid:23995ed4-3c6b-11e9-b210-d663bd873d93";
         actor = Person.builder().id(BASE_IRI.concat("/users/554433")).build();
 
+        List<String> itemLabels = Lists.newArrayList();
+        itemLabels.add("Strongly Disagree");
+        itemLabels.add("Disagree");
+        itemLabels.add("Agree");
+
+        List<String> itemValues = Lists.newArrayList();
+        itemValues.add("-2");
+        itemValues.add("-1");
+        itemValues.add("1");
+
         LikertScale scale = LikertScale.builder()
             .id(BASE_IRI.concat("/scale/2"))
             .scalePoints(4)
-            .itemLabel("Strongly Disagree")
-            .itemLabel("Disagree")
-            .itemLabel("Agree")
+            .itemLabels(itemLabels)
             .itemLabel("Strongly Agree")
-            .itemValue("-2")
-            .itemValue("-1")
-            .itemValue("1")
+            .itemValues(itemValues)
             .itemValue("2")
             .build();
 
@@ -90,10 +99,13 @@ public class QuestionnaireItemEventStartedTest {
             .scale(scale)
             .build();
 
+        List<String> categories = Lists.newArrayList();
+        categories.add("teaching effectiveness");
+
         object = QuestionnaireItem.builder()
             .id(ITEM_IRI)
             .question(question)
-            .category("teaching effectiveness")
+            .categories(categories)
             .category("Course structure")
             .weight(1.0)
             .build();

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/QuestionnaireItemEventStartedTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/QuestionnaireItemEventStartedTest.java
@@ -31,10 +31,11 @@ import org.imsglobal.caliper.entities.agent.Person;
 import org.imsglobal.caliper.entities.agent.Role;
 import org.imsglobal.caliper.entities.agent.SoftwareApplication;
 import org.imsglobal.caliper.entities.agent.Status;
-import org.imsglobal.caliper.entities.resource.DigitalResource;
-import org.imsglobal.caliper.entities.resource.DigitalResourceCollection;
+import org.imsglobal.caliper.entities.question.RatingScaleQuestion;
+import org.imsglobal.caliper.entities.resource.QuestionnaireItem;
+import org.imsglobal.caliper.entities.scale.LikertScale;
 import org.imsglobal.caliper.entities.session.Session;
-import org.imsglobal.caliper.events.ResourceManagementEvent;
+import org.imsglobal.caliper.events.QuestionnaireItemEvent;
 import org.imsglobal.caliper.profiles.CaliperProfile;
 import org.imsglobal.caliper.profiles.Profile;
 import org.joda.time.DateTime;
@@ -49,41 +50,52 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
 @Category(org.imsglobal.caliper.UnitTest.class)
-public class ResourceManagementEventCreatedTest {
+public class QuestionnaireItemEventStartedTest {
     private JsonldContext context;
     private String id;
     private Person actor;
-    private CourseSection section;
-    private DigitalResource object;
-    private DigitalResourceCollection collection;
+    private QuestionnaireItem object;
+    private SoftwareApplication edApp;
     private CourseSection group;
     private Membership membership;
-    private ResourceManagementEvent event;
     private Session session;
-    private SoftwareApplication edApp;
+    private QuestionnaireItemEvent event;
 
     private static final String BASE_IRI = "https://example.edu";
+    private static final String ITEM_IRI = BASE_IRI.concat("/surveys/100/questionnaires/30/items/1");
     private static final String SECTION_IRI = BASE_IRI.concat("/terms/201801/courses/7/sections/1");
 
     @Before
     public void setUp() throws Exception {
         context = JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value());
-        id = "urn:uuid:0c81f804-62ee-4953-81c5-62d9579c4369";
+        id = "urn:uuid:23995ed4-3c6b-11e9-b210-d663bd873d93";
         actor = Person.builder().id(BASE_IRI.concat("/users/554433")).build();
 
-        collection = DigitalResourceCollection.builder()
-            .id(SECTION_IRI.concat("/resources/1"))
-            .name("Course Assets")
-            .isPartOf(CourseSection.builder().id(SECTION_IRI).build())
+        LikertScale scale = LikertScale.builder()
+            .id(BASE_IRI.concat("/scale/2"))
+            .scalePoints(4)
+            .itemLabel("Strongly Disagree")
+            .itemLabel("Disagree")
+            .itemLabel("Agree")
+            .itemLabel("Strongly Agree")
+            .itemValue("-2")
+            .itemValue("-1")
+            .itemValue("1")
+            .itemValue("2")
             .build();
 
-        object = DigitalResource.builder()
-            .id(SECTION_IRI.concat("/resources/1/syllabus.pdf"))
-            .name("Course Syllabus")
-            .creator(actor)
-            .mediaType("application/pdf")
-            .isPartOf(collection)
-            .dateCreated(new DateTime(2018, 8, 2, 11, 32, 0, 0, DateTimeZone.UTC))
+        RatingScaleQuestion question = RatingScaleQuestion.builder()
+            .id(ITEM_IRI.concat("/question"))
+            .questionPosed("How satisfied are you with our services?")
+            .scale(scale)
+            .build();
+
+        object = QuestionnaireItem.builder()
+            .id(ITEM_IRI)
+            .question(question)
+            .category("teaching effectiveness")
+            .category("Course structure")
+            .weight(1.0)
             .build();
 
         edApp = SoftwareApplication.builder().id(BASE_IRI).coercedToId(true).build();
@@ -95,21 +107,21 @@ public class ResourceManagementEventCreatedTest {
             .build();
 
         membership = Membership.builder()
-            .id(BASE_IRI.concat("/terms/201801/courses/7/sections/1/rosters/1"))
-            .member(Person.builder().id(actor.getId()).coercedToId(true).build())
+            .id(SECTION_IRI.concat("/rosters/1"))
+            .role(Role.LEARNER)
+            .member(Person.builder().id(BASE_IRI.concat("/users/554433")).coercedToId(true).build())
             .organization(CourseSection.builder().id(SECTION_IRI).coercedToId(true).build())
             .status(Status.ACTIVE)
-            .role(Role.INSTRUCTOR)
             .dateCreated(new DateTime(2018, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
             .build();
 
         session = Session.builder()
-            .id(BASE_IRI.concat("/sessions/1f6442a482de72ea6ad134943812bff564a76259"))
-            .startedAtTime(new DateTime(2018, 11, 15, 10, 0, 0, 0, DateTimeZone.UTC))
+            .id(BASE_IRI.concat("/sessions/f095bbd391ea4a5dd639724a40b606e98a631823"))
+            .startedAtTime(new DateTime(2018, 11, 12, 10, 0, 0, 0, DateTimeZone.UTC))
             .build();
 
         // Build event
-        event = buildEvent(Profile.RESOURCE_MANAGEMENT, Action.CREATED);
+        event = buildEvent(Profile.SURVEY, Action.STARTED);
     }
 
     @Test
@@ -117,13 +129,13 @@ public class ResourceManagementEventCreatedTest {
         ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
         String json = mapper.writeValueAsString(event);
 
-        String fixture = jsonFixture("fixtures/v1p2/caliperEventResourceManagementCreated.json");
+        String fixture = jsonFixture("fixtures/v1p2/caliperEventQuestionnaireItemStarted.json");
         JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Test(expected=IllegalArgumentException.class)
-    public void resourceManagementEventRejectsLaunchedAction() {
-        buildEvent(Profile.SURVEY, Action.LAUNCHED);
+    public void questionnaireItemEventRejectsTimedOutAction() {
+        buildEvent(Profile.SURVEY, Action.TIMED_OUT);
     }
 
     @After
@@ -132,19 +144,19 @@ public class ResourceManagementEventCreatedTest {
     }
 
     /**
-     * Build ResourceManagementEvent.
+     * Build QuestionnaireItemEvent.
      * @param profile, action
      * @return event
      */
-    private ResourceManagementEvent buildEvent(CaliperProfile profile, CaliperAction action) {
-        return ResourceManagementEvent.builder()
+    private QuestionnaireItemEvent buildEvent(CaliperProfile profile, CaliperAction action) {
+        return QuestionnaireItemEvent.builder()
             .context(context)
-            .profile(profile)
             .id(id)
+            .profile(profile)
             .actor(actor)
             .action(action)
             .object(object)
-            .eventTime(new DateTime(2018, 11, 15, 10, 5, 0, 0, DateTimeZone.UTC))
+            .eventTime(new DateTime(2018, 11, 12, 10, 15, 0, 0, DateTimeZone.UTC))
             .edApp(edApp)
             .group(group)
             .membership(membership)

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/ResourceManagementEventPrintedTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/ResourceManagementEventPrintedTest.java
@@ -49,13 +49,12 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
 @Category(org.imsglobal.caliper.UnitTest.class)
-public class ResourceManagementEventCreatedTest {
+public class ResourceManagementEventPrintedTest {
     private JsonldContext context;
     private String id;
     private Person actor;
     private CourseSection section;
     private DigitalResource object;
-    private DigitalResourceCollection collection;
     private CourseSection group;
     private Membership membership;
     private ResourceManagementEvent event;
@@ -68,10 +67,10 @@ public class ResourceManagementEventCreatedTest {
     @Before
     public void setUp() throws Exception {
         context = JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value());
-        id = "urn:uuid:0c81f804-62ee-4953-81c5-62d9579c4369";
+        id = "urn:uuid:d3543a73-e307-4190-a755-5ce7b3187bc5";
         actor = Person.builder().id(BASE_IRI.concat("/users/554433")).build();
 
-        collection = DigitalResourceCollection.builder()
+        DigitalResourceCollection collection = DigitalResourceCollection.builder()
             .id(SECTION_IRI.concat("/resources/1"))
             .name("Course Assets")
             .isPartOf(CourseSection.builder().id(SECTION_IRI).build())
@@ -109,7 +108,7 @@ public class ResourceManagementEventCreatedTest {
             .build();
 
         // Build event
-        event = buildEvent(Profile.RESOURCE_MANAGEMENT, Action.CREATED);
+        event = buildEvent(Profile.RESOURCE_MANAGEMENT, Action.PRINTED);
     }
 
     @Test
@@ -117,7 +116,7 @@ public class ResourceManagementEventCreatedTest {
         ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
         String json = mapper.writeValueAsString(event);
 
-        String fixture = jsonFixture("fixtures/v1p2/caliperEventResourceManagementCreated.json");
+        String fixture = jsonFixture("fixtures/v1p2/caliperEventResourceManagementPrinted.json");
         JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
     }
 

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/SearchEventSearchedTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/SearchEventSearchedTest.java
@@ -25,7 +25,6 @@ import org.imsglobal.caliper.actions.CaliperAction;
 import org.imsglobal.caliper.context.CaliperJsonldContextIRI;
 import org.imsglobal.caliper.context.JsonldContext;
 import org.imsglobal.caliper.context.JsonldStringContext;
-import org.imsglobal.caliper.entities.CaliperEntity;
 import org.imsglobal.caliper.entities.agent.CourseSection;
 import org.imsglobal.caliper.entities.agent.Membership;
 import org.imsglobal.caliper.entities.agent.Person;
@@ -47,8 +46,6 @@ import org.junit.experimental.categories.Category;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 
-import java.util.List;
-
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
 @Category(org.imsglobal.caliper.UnitTest.class)
@@ -58,7 +55,6 @@ public class SearchEventSearchedTest {
     private Person actor;
     private Person creator;
     private Query query;
-    private List<CaliperEntity> results;
     private SoftwareApplication catalog;
     private SoftwareApplication object;
     private SearchResponse generated;
@@ -132,7 +128,7 @@ public class SearchEventSearchedTest {
     }
 
     @Test(expected=IllegalArgumentException.class)
-    public void viewEventRejectsNavigatedToAction() {
+    public void searchEventRejectsNavigatedToAction() {
         buildEvent(Profile.SEARCH, Action.NAVIGATED_TO);
     }
 
@@ -148,18 +144,18 @@ public class SearchEventSearchedTest {
      */
     private SearchEvent buildEvent(CaliperProfile profile, CaliperAction action) {
         return SearchEvent.builder()
-                .context(context)
-                .profile(profile)
-                .id(id)
-                .actor(actor)
-                .action(action)
-                .object(object)
-                .eventTime(new DateTime(2018, 11, 15, 10, 5, 0, 0, DateTimeZone.UTC))
-                .generated(generated)
-                .edApp(edApp)
-                .group(group)
-                .membership(membership)
-                .session(session)
-                .build();
+            .context(context)
+            .profile(profile)
+            .id(id)
+            .actor(actor)
+            .action(action)
+            .object(object)
+            .eventTime(new DateTime(2018, 11, 15, 10, 5, 0, 0, DateTimeZone.UTC))
+            .generated(generated)
+            .edApp(edApp)
+            .group(group)
+            .membership(membership)
+            .session(session)
+            .build();
     }
 }

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/SearchEventSearchedTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/SearchEventSearchedTest.java
@@ -142,8 +142,8 @@ public class SearchEventSearchedTest {
     }
 
     /**
-     * Build View event
-     * @param action
+     * Build SearchEvent.
+     * @param profile, action
      * @return event
      */
     private SearchEvent buildEvent(CaliperProfile profile, CaliperAction action) {

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/SessionEventLoggedInExtendedTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/SessionEventLoggedInExtendedTest.java
@@ -25,16 +25,10 @@ import org.imsglobal.caliper.actions.CaliperAction;
 import org.imsglobal.caliper.context.CaliperJsonldContextIRI;
 import org.imsglobal.caliper.context.JsonldContext;
 import org.imsglobal.caliper.context.JsonldStringContext;
-import org.imsglobal.caliper.entities.agent.CourseSection;
-import org.imsglobal.caliper.entities.agent.Membership;
 import org.imsglobal.caliper.entities.agent.Person;
-import org.imsglobal.caliper.entities.agent.Role;
 import org.imsglobal.caliper.entities.agent.SoftwareApplication;
-import org.imsglobal.caliper.entities.agent.Status;
-import org.imsglobal.caliper.entities.resource.DigitalResource;
-import org.imsglobal.caliper.entities.resource.DigitalResourceCollection;
 import org.imsglobal.caliper.entities.session.Session;
-import org.imsglobal.caliper.events.ResourceManagementEvent;
+import org.imsglobal.caliper.events.SessionEvent;
 import org.imsglobal.caliper.profiles.CaliperProfile;
 import org.imsglobal.caliper.profiles.Profile;
 import org.joda.time.DateTime;
@@ -49,67 +43,46 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
 @Category(org.imsglobal.caliper.UnitTest.class)
-public class ResourceManagementEventCreatedTest {
+public class SessionEventLoggedInExtendedTest {
     private JsonldContext context;
     private String id;
     private Person actor;
-    private CourseSection section;
-    private DigitalResource object;
-    private DigitalResourceCollection collection;
-    private CourseSection group;
-    private Membership membership;
-    private ResourceManagementEvent event;
+    private SoftwareApplication object, edApp;
     private Session session;
-    private SoftwareApplication edApp;
+    private SessionEvent event;
 
     private static final String BASE_IRI = "https://example.edu";
-    private static final String SECTION_IRI = BASE_IRI.concat("/terms/201801/courses/7/sections/1");
+    private static final String SECTION_IRI = BASE_IRI.concat("/terms/201601/courses/7/sections/1");
 
     @Before
     public void setUp() throws Exception {
         context = JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value());
-        id = "urn:uuid:0c81f804-62ee-4953-81c5-62d9579c4369";
+
+        id = "urn:uuid:4ec2c31e-3ec0-4fe1-a017-b81561b075d7";
+
         actor = Person.builder().id(BASE_IRI.concat("/users/554433")).build();
 
-        collection = DigitalResourceCollection.builder()
-            .id(SECTION_IRI.concat("/resources/1"))
-            .name("Course Assets")
-            .isPartOf(CourseSection.builder().id(SECTION_IRI).build())
-            .build();
+        object = SoftwareApplication.builder().id(BASE_IRI).version("v2").build();
 
-        object = DigitalResource.builder()
-            .id(SECTION_IRI.concat("/resources/1/syllabus.pdf"))
-            .name("Course Syllabus")
-            .creator(actor)
-            .mediaType("application/pdf")
-            .isPartOf(collection)
-            .dateCreated(new DateTime(2018, 8, 2, 11, 32, 0, 0, DateTimeZone.UTC))
-            .build();
+        edApp = SoftwareApplication.builder().id(object.getId()).coercedToId(true).build();
 
-        edApp = SoftwareApplication.builder().id(BASE_IRI).coercedToId(true).build();
-
-        group = CourseSection.builder()
-            .id(SECTION_IRI)
-            .courseNumber("CPS 435-01")
-            .academicSession("Fall 2018")
-            .build();
-
-        membership = Membership.builder()
-            .id(BASE_IRI.concat("/terms/201801/courses/7/sections/1/rosters/1"))
-            .member(Person.builder().id(actor.getId()).coercedToId(true).build())
-            .organization(CourseSection.builder().id(SECTION_IRI).coercedToId(true).build())
-            .status(Status.ACTIVE)
-            .role(Role.INSTRUCTOR)
-            .dateCreated(new DateTime(2018, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
+        SoftwareApplication client = SoftwareApplication.builder()
+            .id("urn:uuid:d71016dc-ed2f-46f9-ac2c-b93f15f38fdc")
+            .host(BASE_IRI)
+            .userAgent("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36")
+            .ipAddress("2001:0db8:85a3:0000:0000:8a2e:0370:7334")
             .build();
 
         session = Session.builder()
             .id(BASE_IRI.concat("/sessions/1f6442a482de72ea6ad134943812bff564a76259"))
-            .startedAtTime(new DateTime(2018, 11, 15, 10, 0, 0, 0, DateTimeZone.UTC))
+            .user(Person.builder().id(actor.getId()).coercedToId(true).build())
+            .client(client)
+            .dateCreated(new DateTime(2016, 11, 15, 20, 11, 15, 0, DateTimeZone.UTC))
+            .startedAtTime(new DateTime(2016, 11, 15, 20, 11, 15, 0, DateTimeZone.UTC))
             .build();
 
         // Build event
-        event = buildEvent(Profile.RESOURCE_MANAGEMENT, Action.CREATED);
+        event = buildEvent(Profile.SESSION, Action.LOGGED_IN);
     }
 
     @Test
@@ -117,13 +90,13 @@ public class ResourceManagementEventCreatedTest {
         ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
         String json = mapper.writeValueAsString(event);
 
-        String fixture = jsonFixture("fixtures/v1p2/caliperEventResourceManagementCreated.json");
+        String fixture = jsonFixture("fixtures/v1p2/caliperEventSessionLoggedInExtended.json");
         JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
     }
 
-    @Test(expected=IllegalArgumentException.class)
-    public void resourceManagementEventRejectsLaunchedAction() {
-        buildEvent(Profile.SURVEY, Action.LAUNCHED);
+    @Test(expected = IllegalArgumentException.class)
+    public void sessionEventRejectsSearchedAction() {
+        buildEvent(Profile.SESSION, Action.SEARCHED);
     }
 
     @After
@@ -132,22 +105,20 @@ public class ResourceManagementEventCreatedTest {
     }
 
     /**
-     * Build ResourceManagementEvent.
+     * Build SessionEvent.
      * @param profile, action
      * @return event
      */
-    private ResourceManagementEvent buildEvent(CaliperProfile profile, CaliperAction action) {
-        return ResourceManagementEvent.builder()
+    private SessionEvent buildEvent(CaliperProfile profile, CaliperAction action) {
+        return SessionEvent.builder()
             .context(context)
-            .profile(profile)
             .id(id)
+            .profile(profile)
             .actor(actor)
             .action(action)
             .object(object)
-            .eventTime(new DateTime(2018, 11, 15, 10, 5, 0, 0, DateTimeZone.UTC))
             .edApp(edApp)
-            .group(group)
-            .membership(membership)
+            .eventTime(new DateTime(2016, 11, 15, 20, 11, 15, 0, DateTimeZone.UTC))
             .session(session)
             .build();
     }

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/SessionEventLoggedInTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/SessionEventLoggedInTest.java
@@ -25,16 +25,10 @@ import org.imsglobal.caliper.actions.CaliperAction;
 import org.imsglobal.caliper.context.CaliperJsonldContextIRI;
 import org.imsglobal.caliper.context.JsonldContext;
 import org.imsglobal.caliper.context.JsonldStringContext;
-import org.imsglobal.caliper.entities.agent.CourseSection;
-import org.imsglobal.caliper.entities.agent.Membership;
 import org.imsglobal.caliper.entities.agent.Person;
-import org.imsglobal.caliper.entities.agent.Role;
 import org.imsglobal.caliper.entities.agent.SoftwareApplication;
-import org.imsglobal.caliper.entities.agent.Status;
-import org.imsglobal.caliper.entities.resource.DigitalResource;
-import org.imsglobal.caliper.entities.resource.DigitalResourceCollection;
 import org.imsglobal.caliper.entities.session.Session;
-import org.imsglobal.caliper.events.ResourceManagementEvent;
+import org.imsglobal.caliper.events.SessionEvent;
 import org.imsglobal.caliper.profiles.CaliperProfile;
 import org.imsglobal.caliper.profiles.Profile;
 import org.joda.time.DateTime;
@@ -49,67 +43,37 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
 @Category(org.imsglobal.caliper.UnitTest.class)
-public class ResourceManagementEventCreatedTest {
+public class SessionEventLoggedInTest {
     private JsonldContext context;
     private String id;
     private Person actor;
-    private CourseSection section;
-    private DigitalResource object;
-    private DigitalResourceCollection collection;
-    private CourseSection group;
-    private Membership membership;
-    private ResourceManagementEvent event;
+    private SoftwareApplication object, edApp;
     private Session session;
-    private SoftwareApplication edApp;
+    private SessionEvent event;
 
     private static final String BASE_IRI = "https://example.edu";
-    private static final String SECTION_IRI = BASE_IRI.concat("/terms/201801/courses/7/sections/1");
 
     @Before
     public void setUp() throws Exception {
         context = JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value());
-        id = "urn:uuid:0c81f804-62ee-4953-81c5-62d9579c4369";
+
+        id = "urn:uuid:fcd495d0-3740-4298-9bec-1154571dc211";
+
         actor = Person.builder().id(BASE_IRI.concat("/users/554433")).build();
 
-        collection = DigitalResourceCollection.builder()
-            .id(SECTION_IRI.concat("/resources/1"))
-            .name("Course Assets")
-            .isPartOf(CourseSection.builder().id(SECTION_IRI).build())
-            .build();
+        object = SoftwareApplication.builder().id(BASE_IRI).version("v2").build();
 
-        object = DigitalResource.builder()
-            .id(SECTION_IRI.concat("/resources/1/syllabus.pdf"))
-            .name("Course Syllabus")
-            .creator(actor)
-            .mediaType("application/pdf")
-            .isPartOf(collection)
-            .dateCreated(new DateTime(2018, 8, 2, 11, 32, 0, 0, DateTimeZone.UTC))
-            .build();
-
-        edApp = SoftwareApplication.builder().id(BASE_IRI).coercedToId(true).build();
-
-        group = CourseSection.builder()
-            .id(SECTION_IRI)
-            .courseNumber("CPS 435-01")
-            .academicSession("Fall 2018")
-            .build();
-
-        membership = Membership.builder()
-            .id(BASE_IRI.concat("/terms/201801/courses/7/sections/1/rosters/1"))
-            .member(Person.builder().id(actor.getId()).coercedToId(true).build())
-            .organization(CourseSection.builder().id(SECTION_IRI).coercedToId(true).build())
-            .status(Status.ACTIVE)
-            .role(Role.INSTRUCTOR)
-            .dateCreated(new DateTime(2018, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
-            .build();
+        edApp = SoftwareApplication.builder().id(object.getId()).coercedToId(true).build();
 
         session = Session.builder()
             .id(BASE_IRI.concat("/sessions/1f6442a482de72ea6ad134943812bff564a76259"))
-            .startedAtTime(new DateTime(2018, 11, 15, 10, 0, 0, 0, DateTimeZone.UTC))
+            .user(Person.builder().id(actor.getId()).coercedToId(true).build())
+            .dateCreated(new DateTime(2016, 11, 15, 10, 0, 0, 0, DateTimeZone.UTC))
+            .startedAtTime(new DateTime(2016, 11, 15, 10, 0, 0, 0, DateTimeZone.UTC))
             .build();
 
         // Build event
-        event = buildEvent(Profile.RESOURCE_MANAGEMENT, Action.CREATED);
+        event = buildEvent(Profile.SESSION, Action.LOGGED_IN);
     }
 
     @Test
@@ -117,14 +81,12 @@ public class ResourceManagementEventCreatedTest {
         ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
         String json = mapper.writeValueAsString(event);
 
-        String fixture = jsonFixture("fixtures/v1p2/caliperEventResourceManagementCreated.json");
+        String fixture = jsonFixture("fixtures/v1p2/caliperEventSessionLoggedIn.json");
         JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Test(expected=IllegalArgumentException.class)
-    public void resourceManagementEventRejectsLaunchedAction() {
-        buildEvent(Profile.SURVEY, Action.LAUNCHED);
-    }
+    public void sessionEventRejectsSearchedAction() { buildEvent(Profile.SESSION, Action.SEARCHED); }
 
     @After
     public void teardown() {
@@ -132,22 +94,20 @@ public class ResourceManagementEventCreatedTest {
     }
 
     /**
-     * Build ResourceManagementEvent.
+     * Build SessionEvent.
      * @param profile, action
      * @return event
      */
-    private ResourceManagementEvent buildEvent(CaliperProfile profile, CaliperAction action) {
-        return ResourceManagementEvent.builder()
+    private SessionEvent buildEvent(CaliperProfile profile, CaliperAction action) {
+        return SessionEvent.builder()
             .context(context)
-            .profile(profile)
             .id(id)
+            .profile(profile)
             .actor(actor)
             .action(action)
             .object(object)
-            .eventTime(new DateTime(2018, 11, 15, 10, 5, 0, 0, DateTimeZone.UTC))
             .edApp(edApp)
-            .group(group)
-            .membership(membership)
+            .eventTime(new DateTime(2016, 11, 15, 10, 15, 0, 0, DateTimeZone.UTC))
             .session(session)
             .build();
     }

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/SessionEventLoggedOutTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/SessionEventLoggedOutTest.java
@@ -25,16 +25,10 @@ import org.imsglobal.caliper.actions.CaliperAction;
 import org.imsglobal.caliper.context.CaliperJsonldContextIRI;
 import org.imsglobal.caliper.context.JsonldContext;
 import org.imsglobal.caliper.context.JsonldStringContext;
-import org.imsglobal.caliper.entities.agent.CourseSection;
-import org.imsglobal.caliper.entities.agent.Membership;
 import org.imsglobal.caliper.entities.agent.Person;
-import org.imsglobal.caliper.entities.agent.Role;
 import org.imsglobal.caliper.entities.agent.SoftwareApplication;
-import org.imsglobal.caliper.entities.agent.Status;
-import org.imsglobal.caliper.entities.resource.DigitalResource;
-import org.imsglobal.caliper.entities.resource.DigitalResourceCollection;
 import org.imsglobal.caliper.entities.session.Session;
-import org.imsglobal.caliper.events.ResourceManagementEvent;
+import org.imsglobal.caliper.events.SessionEvent;
 import org.imsglobal.caliper.profiles.CaliperProfile;
 import org.imsglobal.caliper.profiles.Profile;
 import org.joda.time.DateTime;
@@ -49,67 +43,39 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
 @Category(org.imsglobal.caliper.UnitTest.class)
-public class ResourceManagementEventCreatedTest {
+public class SessionEventLoggedOutTest {
     private JsonldContext context;
     private String id;
     private Person actor;
-    private CourseSection section;
-    private DigitalResource object;
-    private DigitalResourceCollection collection;
-    private CourseSection group;
-    private Membership membership;
-    private ResourceManagementEvent event;
+    private SoftwareApplication object, edApp;
     private Session session;
-    private SoftwareApplication edApp;
+    private SessionEvent event;
 
     private static final String BASE_IRI = "https://example.edu";
-    private static final String SECTION_IRI = BASE_IRI.concat("/terms/201801/courses/7/sections/1");
 
     @Before
     public void setUp() throws Exception {
         context = JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value());
-        id = "urn:uuid:0c81f804-62ee-4953-81c5-62d9579c4369";
+
+        id = "urn:uuid:a438f8ac-1da3-4d48-8c86-94a1b387e0f6";
+
         actor = Person.builder().id(BASE_IRI.concat("/users/554433")).build();
 
-        collection = DigitalResourceCollection.builder()
-            .id(SECTION_IRI.concat("/resources/1"))
-            .name("Course Assets")
-            .isPartOf(CourseSection.builder().id(SECTION_IRI).build())
-            .build();
+        object = SoftwareApplication.builder().id(BASE_IRI).version("v2").build();
 
-        object = DigitalResource.builder()
-            .id(SECTION_IRI.concat("/resources/1/syllabus.pdf"))
-            .name("Course Syllabus")
-            .creator(actor)
-            .mediaType("application/pdf")
-            .isPartOf(collection)
-            .dateCreated(new DateTime(2018, 8, 2, 11, 32, 0, 0, DateTimeZone.UTC))
-            .build();
-
-        edApp = SoftwareApplication.builder().id(BASE_IRI).coercedToId(true).build();
-
-        group = CourseSection.builder()
-            .id(SECTION_IRI)
-            .courseNumber("CPS 435-01")
-            .academicSession("Fall 2018")
-            .build();
-
-        membership = Membership.builder()
-            .id(BASE_IRI.concat("/terms/201801/courses/7/sections/1/rosters/1"))
-            .member(Person.builder().id(actor.getId()).coercedToId(true).build())
-            .organization(CourseSection.builder().id(SECTION_IRI).coercedToId(true).build())
-            .status(Status.ACTIVE)
-            .role(Role.INSTRUCTOR)
-            .dateCreated(new DateTime(2018, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
-            .build();
+        edApp = SoftwareApplication.builder().id(object.getId()).coercedToId(true).build();
 
         session = Session.builder()
             .id(BASE_IRI.concat("/sessions/1f6442a482de72ea6ad134943812bff564a76259"))
-            .startedAtTime(new DateTime(2018, 11, 15, 10, 0, 0, 0, DateTimeZone.UTC))
+            .user(Person.builder().id(actor.getId()).coercedToId(true).build())
+            .dateCreated(new DateTime(2016, 11, 15, 10, 0, 0, 0, DateTimeZone.UTC))
+            .startedAtTime(new DateTime(2016, 11, 15, 10, 0, 0, 0, DateTimeZone.UTC))
+            .endedAtTime(new DateTime(2016, 11, 15, 11, 5, 0, 0, DateTimeZone.UTC))
+            .duration("PT3000S")
             .build();
 
         // Build event
-        event = buildEvent(Profile.RESOURCE_MANAGEMENT, Action.CREATED);
+        event = buildEvent(Profile.SESSION, Action.LOGGED_OUT);
     }
 
     @Test
@@ -117,13 +83,13 @@ public class ResourceManagementEventCreatedTest {
         ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
         String json = mapper.writeValueAsString(event);
 
-        String fixture = jsonFixture("fixtures/v1p2/caliperEventResourceManagementCreated.json");
+        String fixture = jsonFixture("fixtures/v1p2/caliperEventSessionLoggedOut.json");
         JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Test(expected=IllegalArgumentException.class)
-    public void resourceManagementEventRejectsLaunchedAction() {
-        buildEvent(Profile.SURVEY, Action.LAUNCHED);
+    public void sessionEventRejectsMutedAction() {
+        buildEvent(Profile.SESSION, Action.MUTED);
     }
 
     @After
@@ -132,22 +98,20 @@ public class ResourceManagementEventCreatedTest {
     }
 
     /**
-     * Build ResourceManagementEvent.
+     * Build SessionEvent.
      * @param profile, action
      * @return event
      */
-    private ResourceManagementEvent buildEvent(CaliperProfile profile, CaliperAction action) {
-        return ResourceManagementEvent.builder()
+    private SessionEvent buildEvent(CaliperProfile profile, CaliperAction action) {
+        return SessionEvent.builder()
             .context(context)
-            .profile(profile)
             .id(id)
+            .profile(profile)
             .actor(actor)
             .action(action)
             .object(object)
-            .eventTime(new DateTime(2018, 11, 15, 10, 5, 0, 0, DateTimeZone.UTC))
+            .eventTime(new DateTime(2016, 11, 15, 11, 5, 0, 0, DateTimeZone.UTC))
             .edApp(edApp)
-            .group(group)
-            .membership(membership)
             .session(session)
             .build();
     }

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/SurveyEventOptedInTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/SurveyEventOptedInTest.java
@@ -19,7 +19,6 @@
 package org.imsglobal.caliper.v1p2.events;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.Lists;
 import org.imsglobal.caliper.TestUtils;
 import org.imsglobal.caliper.actions.Action;
 import org.imsglobal.caliper.actions.CaliperAction;
@@ -46,8 +45,6 @@ import org.junit.experimental.categories.Category;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 
-import java.util.List;
-
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
 @Category(org.imsglobal.caliper.UnitTest.class)
@@ -68,7 +65,9 @@ public class SurveyEventOptedInTest {
     @Before
     public void setUp() throws Exception {
         context = JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value());
+
         id = "urn:uuid:4bfb7726-3564-11e9-b210-d663bd873d93";
+
         actor = Person.builder().id(BASE_IRI.concat("/users/554433")).build();
 
         object = Survey.builder().id(BASE_IRI.concat("/survey/1")).build();
@@ -81,14 +80,11 @@ public class SurveyEventOptedInTest {
             .academicSession("Fall 2018")
             .build();
 
-        List<Role> roles = Lists.newArrayList();
-        roles.add(Role.LEARNER);
-
         membership = Membership.builder()
             .id(SECTION_IRI.concat("/rosters/1"))
             .member(Person.builder().id(BASE_IRI.concat("/users/554433")).coercedToId(true).build())
             .organization(CourseSection.builder().id(SECTION_IRI).coercedToId(true).build())
-            .roles(roles)
+            .role(Role.LEARNER)
             .status(Status.ACTIVE)
             .dateCreated(new DateTime(2018, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
             .build();

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/SurveyInvitationEventAcceptedTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/SurveyInvitationEventAcceptedTest.java
@@ -19,7 +19,6 @@
 package org.imsglobal.caliper.v1p2.events;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.Lists;
 import org.imsglobal.caliper.TestUtils;
 import org.imsglobal.caliper.actions.Action;
 import org.imsglobal.caliper.actions.CaliperAction;
@@ -46,8 +45,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
-
-import java.util.List;
 
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
@@ -93,14 +90,11 @@ public class SurveyInvitationEventAcceptedTest {
             .academicSession("Fall 2018")
             .build();
 
-        List<Role> roles = Lists.newArrayList();
-        roles.add(Role.LEARNER);
-
         membership = Membership.builder()
             .id(SECTION_IRI.concat("/rosters/1"))
             .member(Person.builder().id(BASE_IRI.concat("/users/554433")).coercedToId(true).build())
             .organization(CourseSection.builder().id(SECTION_IRI).coercedToId(true).build())
-            .roles(roles)
+            .role(Role.LEARNER)
             .status(Status.ACTIVE)
             .dateCreated(new DateTime(2018, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
             .build();
@@ -121,6 +115,11 @@ public class SurveyInvitationEventAcceptedTest {
 
         String fixture = jsonFixture("fixtures/v1p2/caliperEventSurveyInvitationAccepted.json");
         JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void surveyInvitationEventRejectsOptedOutAction() {
+        buildEvent(Profile.SURVEY, Action.OPTED_OUT);
     }
 
     @After

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/SurveyInvitationEventSentTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/SurveyInvitationEventSentTest.java
@@ -19,7 +19,6 @@
 package org.imsglobal.caliper.v1p2.events;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.Lists;
 import org.imsglobal.caliper.TestUtils;
 import org.imsglobal.caliper.actions.Action;
 import org.imsglobal.caliper.actions.CaliperAction;

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/SurveyInvitationEventSentTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/SurveyInvitationEventSentTest.java
@@ -19,6 +19,7 @@
 package org.imsglobal.caliper.v1p2.events;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
 import org.imsglobal.caliper.TestUtils;
 import org.imsglobal.caliper.actions.Action;
 import org.imsglobal.caliper.actions.CaliperAction;
@@ -31,10 +32,10 @@ import org.imsglobal.caliper.entities.agent.Person;
 import org.imsglobal.caliper.entities.agent.Role;
 import org.imsglobal.caliper.entities.agent.SoftwareApplication;
 import org.imsglobal.caliper.entities.agent.Status;
-import org.imsglobal.caliper.entities.resource.DigitalResource;
-import org.imsglobal.caliper.entities.resource.DigitalResourceCollection;
+import org.imsglobal.caliper.entities.resource.SurveyInvitation;
 import org.imsglobal.caliper.entities.session.Session;
-import org.imsglobal.caliper.events.ResourceManagementEvent;
+import org.imsglobal.caliper.entities.survey.Survey;
+import org.imsglobal.caliper.events.SurveyInvitationEvent;
 import org.imsglobal.caliper.profiles.CaliperProfile;
 import org.imsglobal.caliper.profiles.Profile;
 import org.joda.time.DateTime;
@@ -49,18 +50,16 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
 @Category(org.imsglobal.caliper.UnitTest.class)
-public class ResourceManagementEventCreatedTest {
+public class SurveyInvitationEventSentTest {
     private JsonldContext context;
     private String id;
     private Person actor;
-    private CourseSection section;
-    private DigitalResource object;
-    private DigitalResourceCollection collection;
+    private SurveyInvitation object;
     private CourseSection group;
-    private Membership membership;
-    private ResourceManagementEvent event;
-    private Session session;
     private SoftwareApplication edApp;
+    private Membership membership;
+    private Session session;
+    private SurveyInvitationEvent event;
 
     private static final String BASE_IRI = "https://example.edu";
     private static final String SECTION_IRI = BASE_IRI.concat("/terms/201801/courses/7/sections/1");
@@ -68,22 +67,20 @@ public class ResourceManagementEventCreatedTest {
     @Before
     public void setUp() throws Exception {
         context = JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value());
-        id = "urn:uuid:0c81f804-62ee-4953-81c5-62d9579c4369";
-        actor = Person.builder().id(BASE_IRI.concat("/users/554433")).build();
+        id = "urn:uuid:5801f73e-3564-11e9-b210-d663bd873d93";
+        actor = Person.builder().id(BASE_IRI.concat("/users/112233")).build();
 
-        collection = DigitalResourceCollection.builder()
-            .id(SECTION_IRI.concat("/resources/1"))
-            .name("Course Assets")
-            .isPartOf(CourseSection.builder().id(SECTION_IRI).build())
-            .build();
+        Person rater = Person.builder().id(BASE_IRI.concat("/users/554433")).build();
 
-        object = DigitalResource.builder()
-            .id(SECTION_IRI.concat("/resources/1/syllabus.pdf"))
-            .name("Course Syllabus")
-            .creator(actor)
-            .mediaType("application/pdf")
-            .isPartOf(collection)
-            .dateCreated(new DateTime(2018, 8, 2, 11, 32, 0, 0, DateTimeZone.UTC))
+        Survey survey = Survey.builder().id(BASE_IRI.concat("/survey/1")).build();
+
+        object = SurveyInvitation.builder()
+            .id(BASE_IRI.concat("/surveys/100/invitations/users/554433"))
+            .sentCount(1)
+            .dateSent(new DateTime(2018, 11, 15, 10, 5, 0, 0, DateTimeZone.UTC))
+            .rater(rater)
+            .survey(survey)
+            .dateCreated(new DateTime(2018, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
             .build();
 
         edApp = SoftwareApplication.builder().id(BASE_IRI).coercedToId(true).build();
@@ -95,21 +92,21 @@ public class ResourceManagementEventCreatedTest {
             .build();
 
         membership = Membership.builder()
-            .id(BASE_IRI.concat("/terms/201801/courses/7/sections/1/rosters/1"))
-            .member(Person.builder().id(actor.getId()).coercedToId(true).build())
+            .id(SECTION_IRI.concat("/rosters/1"))
+            .member(Person.builder().id(BASE_IRI.concat("/users/112233")).coercedToId(true).build())
             .organization(CourseSection.builder().id(SECTION_IRI).coercedToId(true).build())
-            .status(Status.ACTIVE)
             .role(Role.INSTRUCTOR)
+            .status(Status.ACTIVE)
             .dateCreated(new DateTime(2018, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
             .build();
 
         session = Session.builder()
-            .id(BASE_IRI.concat("/sessions/1f6442a482de72ea6ad134943812bff564a76259"))
-            .startedAtTime(new DateTime(2018, 11, 15, 10, 0, 0, 0, DateTimeZone.UTC))
+            .id(BASE_IRI.concat("/sessions/f095bbd391ea4a5dd639724a40b606e98a631823"))
+            .startedAtTime(new DateTime(2018, 11, 12, 10, 0, 0, 0, DateTimeZone.UTC))
             .build();
 
         // Build event
-        event = buildEvent(Profile.RESOURCE_MANAGEMENT, Action.CREATED);
+        event = buildEvent(Profile.SURVEY, Action.SENT);
     }
 
     @Test
@@ -117,13 +114,13 @@ public class ResourceManagementEventCreatedTest {
         ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
         String json = mapper.writeValueAsString(event);
 
-        String fixture = jsonFixture("fixtures/v1p2/caliperEventResourceManagementCreated.json");
+        String fixture = jsonFixture("fixtures/v1p2/caliperEventSurveyInvitationSent.json");
         JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Test(expected=IllegalArgumentException.class)
-    public void resourceManagementEventRejectsLaunchedAction() {
-        buildEvent(Profile.SURVEY, Action.LAUNCHED);
+    public void surveyInvitationEventRejectsOptedOutAction() {
+        buildEvent(Profile.SURVEY, Action.OPTED_OUT);
     }
 
     @After
@@ -132,19 +129,19 @@ public class ResourceManagementEventCreatedTest {
     }
 
     /**
-     * Build ResourceManagementEvent.
+     * Build SurveyInvitationEvent.
      * @param profile, action
      * @return event
      */
-    private ResourceManagementEvent buildEvent(CaliperProfile profile, CaliperAction action) {
-        return ResourceManagementEvent.builder()
+    private SurveyInvitationEvent buildEvent(CaliperProfile profile, CaliperAction action) {
+        return SurveyInvitationEvent.builder()
             .context(context)
-            .profile(profile)
             .id(id)
+            .profile(profile)
             .actor(actor)
             .action(action)
             .object(object)
-            .eventTime(new DateTime(2018, 11, 15, 10, 5, 0, 0, DateTimeZone.UTC))
+            .eventTime(new DateTime(2018, 11, 12, 10, 15, 0, 0, DateTimeZone.UTC))
             .edApp(edApp)
             .group(group)
             .membership(membership)

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/ThreadEventMarkedAsReadTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/ThreadEventMarkedAsReadTest.java
@@ -31,10 +31,10 @@ import org.imsglobal.caliper.entities.agent.Person;
 import org.imsglobal.caliper.entities.agent.Role;
 import org.imsglobal.caliper.entities.agent.SoftwareApplication;
 import org.imsglobal.caliper.entities.agent.Status;
-import org.imsglobal.caliper.entities.resource.DigitalResource;
-import org.imsglobal.caliper.entities.resource.DigitalResourceCollection;
+import org.imsglobal.caliper.entities.resource.Forum;
+import org.imsglobal.caliper.entities.resource.Thread;
 import org.imsglobal.caliper.entities.session.Session;
-import org.imsglobal.caliper.events.ResourceManagementEvent;
+import org.imsglobal.caliper.events.ThreadEvent;
 import org.imsglobal.caliper.profiles.CaliperProfile;
 import org.imsglobal.caliper.profiles.Profile;
 import org.joda.time.DateTime;
@@ -49,67 +49,65 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
 @Category(org.imsglobal.caliper.UnitTest.class)
-public class ResourceManagementEventCreatedTest {
+public class ThreadEventMarkedAsReadTest {
     private JsonldContext context;
     private String id;
     private Person actor;
-    private CourseSection section;
-    private DigitalResource object;
-    private DigitalResourceCollection collection;
+    private Thread object;
+    private SoftwareApplication edApp;
     private CourseSection group;
     private Membership membership;
-    private ResourceManagementEvent event;
     private Session session;
-    private SoftwareApplication edApp;
+    private ThreadEvent event;
 
     private static final String BASE_IRI = "https://example.edu";
-    private static final String SECTION_IRI = BASE_IRI.concat("/terms/201801/courses/7/sections/1");
+    private static final String SECTION_IRI = BASE_IRI.concat("/terms/201601/courses/7/sections/1");
 
     @Before
     public void setUp() throws Exception {
         context = JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value());
-        id = "urn:uuid:0c81f804-62ee-4953-81c5-62d9579c4369";
+
+        id = "urn:uuid:6b20c5ba-301c-4e56-85a0-2f3d9a94c249";
+
         actor = Person.builder().id(BASE_IRI.concat("/users/554433")).build();
 
-        collection = DigitalResourceCollection.builder()
-            .id(SECTION_IRI.concat("/resources/1"))
-            .name("Course Assets")
-            .isPartOf(CourseSection.builder().id(SECTION_IRI).build())
+        Forum forum = Forum.builder()
+            .id(SECTION_IRI.concat("/forums/1"))
+            .name("Caliper Forum")
+            .dateCreated(new DateTime(2016, 11, 15, 10, 15, 0, 0, DateTimeZone.UTC))
             .build();
 
-        object = DigitalResource.builder()
-            .id(SECTION_IRI.concat("/resources/1/syllabus.pdf"))
-            .name("Course Syllabus")
-            .creator(actor)
-            .mediaType("application/pdf")
-            .isPartOf(collection)
-            .dateCreated(new DateTime(2018, 8, 2, 11, 32, 0, 0, DateTimeZone.UTC))
+        object = Thread.builder()
+            .id(SECTION_IRI.concat("/forums/1/topics/1"))
+            .name("Caliper Information Model")
+            .isPartOf(forum)
+            .dateCreated(new DateTime(2016, 11, 15, 10, 16, 0, 0, DateTimeZone.UTC))
             .build();
 
-        edApp = SoftwareApplication.builder().id(BASE_IRI).coercedToId(true).build();
+        edApp = SoftwareApplication.builder().id(BASE_IRI.concat("/forums")).version("v2").build();
 
         group = CourseSection.builder()
-            .id(SECTION_IRI)
+            .id(BASE_IRI.concat("/terms/201601/courses/7/sections/1"))
             .courseNumber("CPS 435-01")
-            .academicSession("Fall 2018")
+            .academicSession("Fall 2016")
             .build();
 
         membership = Membership.builder()
-            .id(BASE_IRI.concat("/terms/201801/courses/7/sections/1/rosters/1"))
+            .id(BASE_IRI.concat("/terms/201601/courses/7/sections/1/rosters/1"))
             .member(Person.builder().id(actor.getId()).coercedToId(true).build())
-            .organization(CourseSection.builder().id(SECTION_IRI).coercedToId(true).build())
+            .organization(CourseSection.builder().id(group.getId()).coercedToId(true).build())
             .status(Status.ACTIVE)
-            .role(Role.INSTRUCTOR)
-            .dateCreated(new DateTime(2018, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
+            .role(Role.LEARNER)
+            .dateCreated(new DateTime(2016, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
             .build();
 
         session = Session.builder()
             .id(BASE_IRI.concat("/sessions/1f6442a482de72ea6ad134943812bff564a76259"))
-            .startedAtTime(new DateTime(2018, 11, 15, 10, 0, 0, 0, DateTimeZone.UTC))
+            .startedAtTime(new DateTime(2016, 11, 15, 10, 0, 0, 0, DateTimeZone.UTC))
             .build();
 
         // Build event
-        event = buildEvent(Profile.RESOURCE_MANAGEMENT, Action.CREATED);
+        event = buildEvent(Profile.FORUM, Action.MARKED_AS_READ);
     }
 
     @Test
@@ -117,13 +115,13 @@ public class ResourceManagementEventCreatedTest {
         ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
         String json = mapper.writeValueAsString(event);
 
-        String fixture = jsonFixture("fixtures/v1p2/caliperEventResourceManagementCreated.json");
+        String fixture = jsonFixture("fixtures/v1p2/caliperEventThreadMarkedAsRead.json");
         JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Test(expected=IllegalArgumentException.class)
-    public void resourceManagementEventRejectsLaunchedAction() {
-        buildEvent(Profile.SURVEY, Action.LAUNCHED);
+    public void messageEventRejectsStartedAction() {
+        buildEvent(Profile.FORUM, Action.STARTED);
     }
 
     @After
@@ -132,19 +130,19 @@ public class ResourceManagementEventCreatedTest {
     }
 
     /**
-     * Build ResourceManagementEvent.
+     * Build ThreadEvent.
      * @param profile, action
      * @return event
      */
-    private ResourceManagementEvent buildEvent(CaliperProfile profile, CaliperAction action) {
-        return ResourceManagementEvent.builder()
+    private ThreadEvent buildEvent(CaliperProfile profile, CaliperAction action) {
+        return ThreadEvent.builder()
             .context(context)
-            .profile(profile)
             .id(id)
+            .profile(profile)
             .actor(actor)
             .action(action)
             .object(object)
-            .eventTime(new DateTime(2018, 11, 15, 10, 5, 0, 0, DateTimeZone.UTC))
+            .eventTime(new DateTime(2016, 11, 15, 10, 16, 0, 0, DateTimeZone.UTC))
             .edApp(edApp)
             .group(group)
             .membership(membership)

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/ToolLaunchEventLaunchedTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/ToolLaunchEventLaunchedTest.java
@@ -102,14 +102,11 @@ public class ToolLaunchEventLaunchedTest {
             .academicSession("Fall 2018")
             .build();
 
-        List<Role> roles = Lists.newArrayList();
-        roles.add(Role.LEARNER);
-
         membership = Membership.builder()
             .id(SECTION_IRI.concat("/rosters/1"))
             .member(Person.builder().id(BASE_IRI.concat("/users/554433")).coercedToId(true).build())
             .organization(CourseSection.builder().id(SECTION_IRI).coercedToId(true).build())
-            .roles(roles)
+            .role(Role.LEARNER)
             .status(Status.ACTIVE)
             .dateCreated(new DateTime(2018, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
             .build();

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/ToolUseEventUsedAnonymousTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/ToolUseEventUsedAnonymousTest.java
@@ -100,6 +100,11 @@ public class ToolUseEventUsedAnonymousTest {
         JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
     }
 
+    @Test(expected=IllegalArgumentException.class)
+    public void toolUseEventRejectsNavigatedToAction() {
+        buildEvent(Profile.TOOL_USE, Action.NAVIGATED_TO);
+    }
+
     @After
     public void teardown() {
         event = null;

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/ToolUseEventUsedTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/ToolUseEventUsedTest.java
@@ -105,7 +105,7 @@ public class ToolUseEventUsedTest {
     }
 
     @Test(expected=IllegalArgumentException.class)
-    public void viewEventRejectsNavigatedToAction() {
+    public void toolUseEventRejectsNavigatedToAction() {
         buildEvent(Profile.TOOL_USE, Action.NAVIGATED_TO);
     }
 

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/ToolUseEventUsedTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/ToolUseEventUsedTest.java
@@ -31,10 +31,8 @@ import org.imsglobal.caliper.entities.agent.Person;
 import org.imsglobal.caliper.entities.agent.Role;
 import org.imsglobal.caliper.entities.agent.SoftwareApplication;
 import org.imsglobal.caliper.entities.agent.Status;
-import org.imsglobal.caliper.entities.resource.DigitalResource;
-import org.imsglobal.caliper.entities.resource.DigitalResourceCollection;
 import org.imsglobal.caliper.entities.session.Session;
-import org.imsglobal.caliper.events.ResourceManagementEvent;
+import org.imsglobal.caliper.events.ToolUseEvent;
 import org.imsglobal.caliper.profiles.CaliperProfile;
 import org.imsglobal.caliper.profiles.Profile;
 import org.joda.time.DateTime;
@@ -49,67 +47,52 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
 @Category(org.imsglobal.caliper.UnitTest.class)
-public class ResourceManagementEventCreatedTest {
+public class ToolUseEventUsedTest {
     private JsonldContext context;
     private String id;
     private Person actor;
-    private CourseSection section;
-    private DigitalResource object;
-    private DigitalResourceCollection collection;
+    private SoftwareApplication object, edApp;
     private CourseSection group;
     private Membership membership;
-    private ResourceManagementEvent event;
     private Session session;
-    private SoftwareApplication edApp;
+    private ToolUseEvent event;
 
     private static final String BASE_IRI = "https://example.edu";
-    private static final String SECTION_IRI = BASE_IRI.concat("/terms/201801/courses/7/sections/1");
 
     @Before
     public void setUp() throws Exception {
         context = JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value());
-        id = "urn:uuid:0c81f804-62ee-4953-81c5-62d9579c4369";
+
+        id = "urn:uuid:7e10e4f3-a0d8-4430-95bd-783ffae4d916";
+
         actor = Person.builder().id(BASE_IRI.concat("/users/554433")).build();
 
-        collection = DigitalResourceCollection.builder()
-            .id(SECTION_IRI.concat("/resources/1"))
-            .name("Course Assets")
-            .isPartOf(CourseSection.builder().id(SECTION_IRI).build())
-            .build();
+        object = SoftwareApplication.builder().id(BASE_IRI).build();
 
-        object = DigitalResource.builder()
-            .id(SECTION_IRI.concat("/resources/1/syllabus.pdf"))
-            .name("Course Syllabus")
-            .creator(actor)
-            .mediaType("application/pdf")
-            .isPartOf(collection)
-            .dateCreated(new DateTime(2018, 8, 2, 11, 32, 0, 0, DateTimeZone.UTC))
-            .build();
-
-        edApp = SoftwareApplication.builder().id(BASE_IRI).coercedToId(true).build();
+        edApp = SoftwareApplication.builder().id(object.getId()).coercedToId(true).build();
 
         group = CourseSection.builder()
-            .id(SECTION_IRI)
+            .id(BASE_IRI.concat("/terms/201601/courses/7/sections/1"))
             .courseNumber("CPS 435-01")
-            .academicSession("Fall 2018")
+            .academicSession("Fall 2016")
             .build();
 
         membership = Membership.builder()
-            .id(BASE_IRI.concat("/terms/201801/courses/7/sections/1/rosters/1"))
+            .id(BASE_IRI.concat("/terms/201601/courses/7/sections/1/rosters/1"))
             .member(Person.builder().id(actor.getId()).coercedToId(true).build())
-            .organization(CourseSection.builder().id(SECTION_IRI).coercedToId(true).build())
+            .organization(CourseSection.builder().id(group.getId()).coercedToId(true).build())
             .status(Status.ACTIVE)
-            .role(Role.INSTRUCTOR)
-            .dateCreated(new DateTime(2018, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
+            .role(Role.LEARNER)
+            .dateCreated(new DateTime(2016, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
             .build();
 
         session = Session.builder()
             .id(BASE_IRI.concat("/sessions/1f6442a482de72ea6ad134943812bff564a76259"))
-            .startedAtTime(new DateTime(2018, 11, 15, 10, 0, 0, 0, DateTimeZone.UTC))
+            .startedAtTime(new DateTime(2016, 11, 15, 10, 0, 0, 0, DateTimeZone.UTC))
             .build();
 
         // Build event
-        event = buildEvent(Profile.RESOURCE_MANAGEMENT, Action.CREATED);
+        event = buildEvent(Profile.TOOL_USE, Action.USED);
     }
 
     @Test
@@ -117,13 +100,13 @@ public class ResourceManagementEventCreatedTest {
         ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
         String json = mapper.writeValueAsString(event);
 
-        String fixture = jsonFixture("fixtures/v1p2/caliperEventResourceManagementCreated.json");
+        String fixture = jsonFixture("fixtures/v1p2/caliperEventToolUseUsed.json");
         JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Test(expected=IllegalArgumentException.class)
-    public void resourceManagementEventRejectsLaunchedAction() {
-        buildEvent(Profile.SURVEY, Action.LAUNCHED);
+    public void viewEventRejectsNavigatedToAction() {
+        buildEvent(Profile.TOOL_USE, Action.NAVIGATED_TO);
     }
 
     @After
@@ -132,19 +115,19 @@ public class ResourceManagementEventCreatedTest {
     }
 
     /**
-     * Build ResourceManagementEvent.
+     * Build ToolUseEvent.
      * @param profile, action
      * @return event
      */
-    private ResourceManagementEvent buildEvent(CaliperProfile profile, CaliperAction action) {
-        return ResourceManagementEvent.builder()
+    private ToolUseEvent buildEvent(CaliperProfile profile, CaliperAction action) {
+        return ToolUseEvent.builder()
             .context(context)
-            .profile(profile)
             .id(id)
+            .profile(profile)
             .actor(actor)
             .action(action)
             .object(object)
-            .eventTime(new DateTime(2018, 11, 15, 10, 5, 0, 0, DateTimeZone.UTC))
+            .eventTime(new DateTime(2016, 11, 15, 10, 15, 0, 0, DateTimeZone.UTC))
             .edApp(edApp)
             .group(group)
             .membership(membership)

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/ToolUseEventUsedWithProgressTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/ToolUseEventUsedWithProgressTest.java
@@ -170,7 +170,7 @@ public class ToolUseEventUsedWithProgressTest {
     }
 
     /**
-     * Build Tool Use Event
+     * Build ToolUseEvent.
      * @param profile, action
      * @return event
      */

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/ToolUseEventUsedWithProgressTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/ToolUseEventUsedWithProgressTest.java
@@ -160,7 +160,7 @@ public class ToolUseEventUsedWithProgressTest {
     }
 
     @Test(expected=IllegalArgumentException.class)
-    public void viewEventRejectsNavigatedToAction() {
+    public void toolUseEventRejectsNavigatedToAction() {
         buildEvent(Profile.TOOL_USE, Action.NAVIGATED_TO);
     }
 

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/ViewEventViewedDocumentExtendedTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/ViewEventViewedDocumentExtendedTest.java
@@ -18,7 +18,9 @@
 
 package org.imsglobal.caliper.v1p2.events;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Maps;
 import org.imsglobal.caliper.TestUtils;
 import org.imsglobal.caliper.actions.Action;
 import org.imsglobal.caliper.actions.CaliperAction;
@@ -31,10 +33,9 @@ import org.imsglobal.caliper.entities.agent.Person;
 import org.imsglobal.caliper.entities.agent.Role;
 import org.imsglobal.caliper.entities.agent.SoftwareApplication;
 import org.imsglobal.caliper.entities.agent.Status;
-import org.imsglobal.caliper.entities.resource.DigitalResource;
-import org.imsglobal.caliper.entities.resource.DigitalResourceCollection;
+import org.imsglobal.caliper.entities.resource.Document;
 import org.imsglobal.caliper.entities.session.Session;
-import org.imsglobal.caliper.events.ResourceManagementEvent;
+import org.imsglobal.caliper.events.ViewEvent;
 import org.imsglobal.caliper.profiles.CaliperProfile;
 import org.imsglobal.caliper.profiles.Profile;
 import org.joda.time.DateTime;
@@ -46,70 +47,68 @@ import org.junit.experimental.categories.Category;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 
+import java.util.Map;
+
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
 @Category(org.imsglobal.caliper.UnitTest.class)
-public class ResourceManagementEventCreatedTest {
+public class ViewEventViewedDocumentExtendedTest {
     private JsonldContext context;
     private String id;
     private Person actor;
-    private CourseSection section;
-    private DigitalResource object;
-    private DigitalResourceCollection collection;
+    private Document object;
+    private SoftwareApplication edApp;
     private CourseSection group;
     private Membership membership;
-    private ResourceManagementEvent event;
     private Session session;
-    private SoftwareApplication edApp;
+    private ViewEvent event;
+    private Map<String, Object> extensions;
 
     private static final String BASE_IRI = "https://example.edu";
-    private static final String SECTION_IRI = BASE_IRI.concat("/terms/201801/courses/7/sections/1");
 
     @Before
     public void setUp() throws Exception {
         context = JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value());
-        id = "urn:uuid:0c81f804-62ee-4953-81c5-62d9579c4369";
+
+        id = "urn:uuid:3a9bd869-addc-48b1-80f6-a14b2ff591ed";
+
         actor = Person.builder().id(BASE_IRI.concat("/users/554433")).build();
 
-        collection = DigitalResourceCollection.builder()
-            .id(SECTION_IRI.concat("/resources/1"))
-            .name("Course Assets")
-            .isPartOf(CourseSection.builder().id(SECTION_IRI).build())
-            .build();
-
-        object = DigitalResource.builder()
-            .id(SECTION_IRI.concat("/resources/1/syllabus.pdf"))
-            .name("Course Syllabus")
-            .creator(actor)
-            .mediaType("application/pdf")
-            .isPartOf(collection)
-            .dateCreated(new DateTime(2018, 8, 2, 11, 32, 0, 0, DateTimeZone.UTC))
+        object = Document.builder()
+            .id(BASE_IRI.concat("/etexts/200.epub"))
+            .name("IMS Caliper Specification")
+            .version("1.1")
             .build();
 
         edApp = SoftwareApplication.builder().id(BASE_IRI).coercedToId(true).build();
 
         group = CourseSection.builder()
-            .id(SECTION_IRI)
+            .id(BASE_IRI.concat("/terms/201601/courses/7/sections/1"))
             .courseNumber("CPS 435-01")
-            .academicSession("Fall 2018")
+            .academicSession("Fall 2016")
             .build();
 
         membership = Membership.builder()
-            .id(BASE_IRI.concat("/terms/201801/courses/7/sections/1/rosters/1"))
+            .id(BASE_IRI.concat("/terms/201601/courses/7/sections/1/rosters/1"))
             .member(Person.builder().id(actor.getId()).coercedToId(true).build())
-            .organization(CourseSection.builder().id(SECTION_IRI).coercedToId(true).build())
+            .organization(CourseSection.builder().id(group.getId()).coercedToId(true).build())
             .status(Status.ACTIVE)
-            .role(Role.INSTRUCTOR)
-            .dateCreated(new DateTime(2018, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
+            .role(Role.LEARNER)
+            .dateCreated(new DateTime(2016, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
             .build();
 
         session = Session.builder()
             .id(BASE_IRI.concat("/sessions/1f6442a482de72ea6ad134943812bff564a76259"))
-            .startedAtTime(new DateTime(2018, 11, 15, 10, 0, 0, 0, DateTimeZone.UTC))
+            .startedAtTime(new DateTime(2016, 11, 15, 10, 0, 0, 0, DateTimeZone.UTC))
             .build();
 
+        // Add extensions
+        Job job = Job.create();
+        extensions = Maps.newHashMap();
+        extensions.put("job", job);
+
         // Build event
-        event = buildEvent(Profile.RESOURCE_MANAGEMENT, Action.CREATED);
+        event = buildEvent(Profile.READING, Action.VIEWED);
     }
 
     @Test
@@ -117,14 +116,12 @@ public class ResourceManagementEventCreatedTest {
         ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
         String json = mapper.writeValueAsString(event);
 
-        String fixture = jsonFixture("fixtures/v1p2/caliperEventResourceManagementCreated.json");
+        String fixture = jsonFixture("fixtures/v1p2/caliperEventViewViewedDocumentExtended.json");
         JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Test(expected=IllegalArgumentException.class)
-    public void resourceManagementEventRejectsLaunchedAction() {
-        buildEvent(Profile.SURVEY, Action.LAUNCHED);
-    }
+    public void viewEventRejectsNavigatedToAction() { buildEvent(Profile.READING, Action.NAVIGATED_TO); }
 
     @After
     public void teardown() {
@@ -132,23 +129,77 @@ public class ResourceManagementEventCreatedTest {
     }
 
     /**
-     * Build ResourceManagementEvent.
+     * Build ViewEvent.
      * @param profile, action
      * @return event
      */
-    private ResourceManagementEvent buildEvent(CaliperProfile profile, CaliperAction action) {
-        return ResourceManagementEvent.builder()
+    private ViewEvent buildEvent(CaliperProfile profile, CaliperAction action) {
+        return ViewEvent.builder()
             .context(context)
-            .profile(profile)
             .id(id)
+            .profile(profile)
             .actor(actor)
             .action(action)
             .object(object)
-            .eventTime(new DateTime(2018, 11, 15, 10, 5, 0, 0, DateTimeZone.UTC))
+            .eventTime(new DateTime(2016, 11, 15, 10, 15, 0, 0, DateTimeZone.UTC))
             .edApp(edApp)
             .group(group)
             .membership(membership)
             .session(session)
+            .extensions(extensions)
             .build();
+    }
+
+    /**
+     * Job extension
+     */
+    static class Job {
+        private String id;
+        private String jobTag;
+        private DateTime jobDate;
+
+        /**
+         * Constructor
+         */
+        private Job() {
+            this.id = "08c1233d-9ba3-40ac-952f-004c47a50ff7";
+            this.jobTag = "caliper_batch_job";
+            this.jobDate = new DateTime(2016, 11, 16, 1, 1, 0, 0, DateTimeZone.UTC);
+        }
+
+        /**
+         * Get the Job identifier.
+         * @return the id
+         */
+        @JsonProperty("id")
+        private String getId() {
+            return id;
+        }
+
+        /**
+         * Get the Job Tag.
+         * @return the jobTag
+         */
+        @JsonProperty("jobTag")
+        private String getJobTag() {
+            return jobTag;
+        }
+
+        /**
+         * Get the Job Date.
+         * @return the jobDate
+         */
+        @JsonProperty("jobDate")
+        private DateTime getJobDate() {
+            return jobDate;
+        }
+
+        /**
+         * Factory method
+         * @return new Job
+         */
+        private static Job create() {
+            return new Job();
+        }
     }
 }

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/ViewEventViewedDocumentFedSessionTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/ViewEventViewedDocumentFedSessionTest.java
@@ -33,18 +33,13 @@ import org.imsglobal.caliper.entities.agent.Person;
 import org.imsglobal.caliper.entities.agent.Role;
 import org.imsglobal.caliper.entities.agent.SoftwareApplication;
 import org.imsglobal.caliper.entities.agent.Status;
+import org.imsglobal.caliper.entities.resource.Document;
 import org.imsglobal.caliper.entities.resource.LtiMessageType;
 import org.imsglobal.caliper.entities.resource.WebPage;
 import org.imsglobal.caliper.entities.session.LtiSession;
 import org.imsglobal.caliper.entities.session.Session;
-import org.imsglobal.caliper.events.ToolLaunchEvent;
-import org.imsglobal.caliper.lti.ContextClaim;
-import org.imsglobal.caliper.lti.CustomClaim;
-import org.imsglobal.caliper.lti.LaunchPresentationClaim;
-import org.imsglobal.caliper.lti.LisClaim;
-import org.imsglobal.caliper.lti.MessageParameterSession;
-import org.imsglobal.caliper.lti.ResourceLinkClaim;
-import org.imsglobal.caliper.lti.ToolPlatformClaim;
+import org.imsglobal.caliper.events.ViewEvent;
+import org.imsglobal.caliper.lti.*;
 import org.imsglobal.caliper.profiles.CaliperProfile;
 import org.imsglobal.caliper.profiles.Profile;
 import org.joda.time.DateTime;
@@ -62,76 +57,76 @@ import java.util.Map;
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
 @Category(org.imsglobal.caliper.UnitTest.class)
-public class ToolLaunchEventLaunchedTest {
+public class ViewEventViewedDocumentFedSessionTest {
     private JsonldContext context;
     private String id;
     private Person actor;
-    private SoftwareApplication object;
-    private WebPage referrer;
-    private CourseSection group;
+    private Document object;
     private SoftwareApplication edApp;
+    private CourseSection group;
     private Membership membership;
-    private Session session;
+    private WebPage referrer;
     private LtiSession federatedSession;
-    private ToolLaunchEvent event;
+    private Session session;
+    private ViewEvent event;
 
-    private static final String BASE_IRI = "https://example.edu";
-    private static final String SECTION_IRI = BASE_IRI.concat("/terms/201801/courses/7/sections/1");
-    private static final String LTI_IRI = "https://purl.imsglobal.org/spec/lti/claim";
-    private static final String LIS_IRI = "http://purl.imsglobal.org/vocab/lis/v2";
+    private static final String BASE_IRI_COM = "https://example.com";
+    private static final String BASE_IRI_EDU = "https://example.edu";
 
     @Before
     public void setUp() throws Exception {
         context = JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value());
-        id = "urn:uuid:a2e8b214-4d4a-4456-bb4c-099945749117";
-        actor = Person.builder().id(BASE_IRI.concat("/users/554433")).build();
 
-        object = SoftwareApplication.builder()
-            .id("https://example.com/lti/tool")
+        id = "urn:uuid:4be6d29d-5728-44cd-8a8f-3d3f07e46b61";
+
+        actor = Person.builder().id(BASE_IRI_EDU.concat("/users/554433")).build();
+        Person actorToId = Person.builder().id(actor.getId()).coercedToId(true).build();
+
+        object = Document.builder()
+            .id(BASE_IRI_COM.concat("/lti/reader/202.epub"))
+            .mediaType("application/epub+zip")
+            .name("Caliper Case Studies")
+            .dateCreated(new DateTime(2018, 8, 1, 9, 0, 0, 0, DateTimeZone.UTC))
             .build();
 
-        edApp = SoftwareApplication.builder().id(BASE_IRI).build();
+        edApp = SoftwareApplication.builder().id(BASE_IRI_COM).coercedToId(true).build();
 
-        referrer = WebPage.builder()
-            .id(BASE_IRI.concat("/terms/201801/courses/7/sections/1/pages/1"))
-            .build();
+        Map<String, Object> groupExtensions = Maps.newHashMap();
+        groupExtensions.put("edu_example_course_section_instructor", "https://example.edu/faculty/1234");
 
         group = CourseSection.builder()
-            .id(SECTION_IRI)
-            .courseNumber("CPS 435-01")
-            .academicSession("Fall 2018")
+            .id(BASE_IRI_EDU.concat("/terms/201801/courses/7/sections/1"))
+            .extensions(groupExtensions)
             .build();
 
-        List<Role> roles = Lists.newArrayList();
-        roles.add(Role.LEARNER);
-
         membership = Membership.builder()
-            .id(SECTION_IRI.concat("/rosters/1"))
-            .member(Person.builder().id(BASE_IRI.concat("/users/554433")).coercedToId(true).build())
-            .organization(CourseSection.builder().id(SECTION_IRI).coercedToId(true).build())
-            .roles(roles)
+            .id(BASE_IRI_EDU.concat("/terms/201801/courses/7/sections/1/rosters/1"))
+            .member(actorToId)
+            .organization(CourseSection.builder().id(group.getId()).coercedToId(true).build())
             .status(Status.ACTIVE)
+            .role(Role.LEARNER)
             .dateCreated(new DateTime(2018, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
             .build();
 
         session = Session.builder()
-            .id(BASE_IRI.concat("/sessions/1f6442a482de72ea6ad134943812bff564a76259"))
-            .startedAtTime(new DateTime(2018, 11, 15, 10, 0, 0, 0, DateTimeZone.UTC))
+            .id(BASE_IRI_COM.concat("/sessions/c25fd3da-87fa-45f5-8875-b682113fa5ee"))
+            .dateCreated(new DateTime(2018, 11, 15, 10, 20, 0, 0, DateTimeZone.UTC))
+            .startedAtTime(new DateTime(2018, 11, 15, 10, 20, 0, 0, DateTimeZone.UTC))
             .build();
 
         Map<String, Object> messageParameters = Maps.newHashMap();
         messageParameters.putAll(getMessageParameters());
 
         federatedSession = LtiSession.builder()
-            .id(BASE_IRI.concat("/lti/sessions/b533eb02823f31024e6b7f53436c42fb99b31241"))
+            .id(BASE_IRI_EDU.concat("/lti/sessions/b533eb02823f31024e6b7f53436c42fb99b31241"))
             .user(actor)
+            .messageParameters(messageParameters)
             .dateCreated(new DateTime(2018, 11, 15, 10, 15, 0, 0, DateTimeZone.UTC))
             .startedAtTime(new DateTime(2018, 11, 15, 10, 15, 0, 0, DateTimeZone.UTC))
-            .messageParameters(messageParameters)
             .build();
 
         // Build event
-        event = buildEvent(Profile.TOOL_LAUNCH, Action.LAUNCHED);
+        event = buildEvent(Profile.READING, Action.VIEWED);
     }
 
     @Test
@@ -139,13 +134,13 @@ public class ToolLaunchEventLaunchedTest {
         ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
         String json = mapper.writeValueAsString(event);
 
-        String fixture = jsonFixture("fixtures/v1p2/caliperEventToolLaunchLaunched.json");
+        String fixture = jsonFixture("fixtures/v1p2/caliperEventViewViewedDocumentFedSession.json");
         JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
     }
 
-    @Test(expected=IllegalArgumentException.class)
-    public void toolLaunchEventRejectsNavigatedToAction() {
-        buildEvent(Profile.TOOL_LAUNCH, Action.NAVIGATED_TO);
+    @Test(expected = IllegalArgumentException.class)
+    public void navigationEventRejectsViewedAction() {
+        buildEvent(Profile.READING, Action.NAVIGATED_TO);
     }
 
     @After
@@ -154,21 +149,20 @@ public class ToolLaunchEventLaunchedTest {
     }
 
     /**
-     * Build ToolLaunchEvent.
+     * Build ViewEvent.
      * @param profile, action
      * @return event
      */
-    private ToolLaunchEvent buildEvent(CaliperProfile profile, CaliperAction action) {
-        return ToolLaunchEvent.builder()
+    private ViewEvent buildEvent(CaliperProfile profile, CaliperAction action) {
+        return ViewEvent.builder()
             .context(context)
             .id(id)
             .profile(profile)
             .actor(actor)
             .action(action)
             .object(object)
-            .eventTime(new DateTime(2018, 11, 15, 10, 15, 0, 0, DateTimeZone.UTC))
+            .eventTime(new DateTime(2018, 11, 15, 10, 20, 0, 0, DateTimeZone.UTC))
             .edApp(edApp)
-            .referrer(referrer)
             .group(group)
             .membership(membership)
             .session(session)
@@ -178,6 +172,7 @@ public class ToolLaunchEventLaunchedTest {
 
     /**
      * LTI message parameters
+     *
      * @return messageParameters
      */
     private Map<String, Object> getMessageParameters() {
@@ -187,8 +182,8 @@ public class ToolLaunchEventLaunchedTest {
 
         List<String> auds = Lists.newArrayList();
         auds.add("https://example.com/lti/tool");
-        params.put("aud", auds);
 
+        params.put("aud", auds);
         params.put("exp", 1510185728);
         params.put("iat", 1510185228);
         params.put("azp", "962fa4d8-bcbf-49a0-94b2-2de05ad274af");
@@ -200,37 +195,60 @@ public class ToolLaunchEventLaunchedTest {
         params.put("picture", "https://example.edu/jane.jpg");
         params.put("email", "jane@example.edu");
         params.put("locale", "en-US");
-        params.put(LTI_IRI.concat("/deployment_id"), "07940580-b309-415e-a37c-914d387c1150");
-        params.put(LTI_IRI.concat("/message_type"), LtiMessageType.LTI_RESOURCE_LINK_REQUEST);
-        params.put(LTI_IRI.concat("/version"), "1.3.0");
+        params.put("https://purl.imsglobal.org/spec/lti/claim/deployment_id", "07940580-b309-415e-a37c-914d387c1150");
+        params.put("https://purl.imsglobal.org/spec/lti/claim/message_type", LtiMessageType.LTI_RESOURCE_LINK_REQUEST);
+        params.put("https://purl.imsglobal.org/spec/lti/claim/version", "1.3.0");
 
         List<String> roles = Lists.newArrayList();
-        roles.add(LIS_IRI.concat("/institution/person#Student"));
-        roles.add(LIS_IRI.concat("/membership#Learner"));
-        roles.add(LIS_IRI.concat("/membership#Mentor"));
-        params.put(LTI_IRI.concat("/roles"), roles);
+        roles.add("http://purl.imsglobal.org/vocab/lis/v2/institution/person#Student");
+        roles.add("http://purl.imsglobal.org/vocab/lis/v2/membership#Learner");
+        roles.add("http://purl.imsglobal.org/vocab/lis/v2/membership#Mentor");
+
+        params.put("https://purl.imsglobal.org/spec/lti/claim/roles", roles);
 
         List<String> mentors = Lists.newArrayList();
-        mentors.add(LIS_IRI.concat("/institution/person#Administrator"));
-        params.put(LTI_IRI.concat("/role_scope_mentor"), mentors);
+        mentors.add("http://purl.imsglobal.org/vocab/lis/v2/institution/person#Administrator");
+
+        params.put("https://purl.imsglobal.org/spec/lti/claim/role_scope_mentor", mentors);
 
         List<String> types = Lists.newArrayList();
-        types.add(LIS_IRI.concat("/course#CourseSection"));
+        types.add("http://purl.imsglobal.org/vocab/lis/v2/course#CourseSection");
 
         ContextClaim contextClaim = ContextClaim.builder()
-            .id(SECTION_IRI)
+            .id("https://example.edu/terms/201801/courses/7/sections/1")
             .label("CPS 435-01")
             .title("CPS 435 Learning Analytics, Section 01")
             .type(types)
             .build();
-        params.put(LTI_IRI.concat("/context"), contextClaim);
+        params.put("https://purl.imsglobal.org/spec/lti/claim/context", contextClaim);
+
+        CustomClaim customClaim = CustomClaim.builder()
+            .xstart("2017-04-21T01:00:00Z")
+            .requestURL("https://tool.com/link/123")
+            .build();
+        params.put("https://purl.imsglobal.org/spec/lti/claim/custom", customClaim);
+
+        LaunchPresentationClaim launchPresentationClaim = LaunchPresentationClaim.builder()
+            .documentTarget("iframe")
+            .height(320)
+            .width(240)
+            .returnUrl("https://example.edu/terms/201801/courses/7/sections/1/pages/1")
+            .build();
+        params.put("https://purl.imsglobal.org/spec/lti/claim/launch_presentation", launchPresentationClaim);
+
+        LisClaim lisClaim = LisClaim.builder()
+            .personSourcedId("example.edu:71ee7e42-f6d2-414a-80db-b69ac2defd4")
+            .courseOfferingSourcedId("example.edu:SI182-F18")
+            .courseSectionSourcedId("example.edu:SI182-001-F18")
+            .build();
+        params.put("https://purl.imsglobal.org/spec/lti/claim/lis", lisClaim);
 
         ResourceLinkClaim resourceLinkClaim = ResourceLinkClaim.builder()
             .id("200d101f-2c14-434a-a0f3-57c2a42369fd")
             .description("Assignment to introduce who you are")
             .title("Introduction Assignment")
             .build();
-        params.put(LTI_IRI.concat("/resource_link"), resourceLinkClaim);
+        params.put("https://purl.imsglobal.org/spec/lti/claim/resource_link", resourceLinkClaim);
 
         ToolPlatformClaim toolPlatformClaim = ToolPlatformClaim.builder()
             .guid("https://example.edu")
@@ -241,32 +259,9 @@ public class ToolLaunchEventLaunchedTest {
             .productFamilyCode("ExamplePlatformVendor-Product")
             .version("1.0")
             .build();
-        params.put(LTI_IRI.concat("/tool_platform"), toolPlatformClaim);
+        params.put("https://purl.imsglobal.org/spec/lti/claim/tool_platform", toolPlatformClaim);
 
-        LaunchPresentationClaim launchPresentationClaim = LaunchPresentationClaim.builder()
-            .documentTarget("iframe")
-            .height(320)
-            .width(240)
-            .returnUrl(SECTION_IRI.concat("/pages/1"))
-            .build();
-        params.put(LTI_IRI.concat("/launch_presentation"), launchPresentationClaim);
-
-        CustomClaim customClaim = CustomClaim.builder()
-            .xstart("2017-04-21T01:00:00Z")
-            .requestURL("https://tool.com/link/123")
-            .build();
-        params.put(LTI_IRI.concat("/custom"), customClaim);
-
-        LisClaim lisClaim = LisClaim.builder()
-            .personSourcedId("example.edu:71ee7e42-f6d2-414a-80db-b69ac2defd4")
-            .courseOfferingSourcedId("example.edu:SI182-F16")
-            .courseSectionSourcedId("example.edu:SI182-001-F16")
-            .build();
-        params.put(LTI_IRI.concat("/lis"), lisClaim);
-
-        MessageParameterSession messageParamSession = MessageParameterSession.builder()
-            .id("89023sj890dju080")
-            .build();
+        MessageParameterSession messageParamSession = MessageParameterSession.builder().id("89023sj890dju080").build();
         params.put("http://www.ExamplePlatformVendor.com/session", messageParamSession);
 
         return params;

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/ViewEventViewedDocumentTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/ViewEventViewedDocumentTest.java
@@ -31,10 +31,9 @@ import org.imsglobal.caliper.entities.agent.Person;
 import org.imsglobal.caliper.entities.agent.Role;
 import org.imsglobal.caliper.entities.agent.SoftwareApplication;
 import org.imsglobal.caliper.entities.agent.Status;
-import org.imsglobal.caliper.entities.resource.DigitalResource;
-import org.imsglobal.caliper.entities.resource.DigitalResourceCollection;
+import org.imsglobal.caliper.entities.resource.Document;
 import org.imsglobal.caliper.entities.session.Session;
-import org.imsglobal.caliper.events.ResourceManagementEvent;
+import org.imsglobal.caliper.events.ViewEvent;
 import org.imsglobal.caliper.profiles.CaliperProfile;
 import org.imsglobal.caliper.profiles.Profile;
 import org.joda.time.DateTime;
@@ -49,81 +48,74 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
 @Category(org.imsglobal.caliper.UnitTest.class)
-public class ResourceManagementEventCreatedTest {
+public class ViewEventViewedDocumentTest {
     private JsonldContext context;
     private String id;
     private Person actor;
-    private CourseSection section;
-    private DigitalResource object;
-    private DigitalResourceCollection collection;
+    private Document object;
+    private SoftwareApplication edApp;
     private CourseSection group;
     private Membership membership;
-    private ResourceManagementEvent event;
     private Session session;
-    private SoftwareApplication edApp;
+    private ViewEvent event;
 
     private static final String BASE_IRI = "https://example.edu";
-    private static final String SECTION_IRI = BASE_IRI.concat("/terms/201801/courses/7/sections/1");
 
     @Before
     public void setUp() throws Exception {
         context = JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value());
-        id = "urn:uuid:0c81f804-62ee-4953-81c5-62d9579c4369";
+
+        id = "urn:uuid:cd088ca7-c044-405c-bb41-0b2a8506f907";
+
         actor = Person.builder().id(BASE_IRI.concat("/users/554433")).build();
 
-        collection = DigitalResourceCollection.builder()
-            .id(SECTION_IRI.concat("/resources/1"))
-            .name("Course Assets")
-            .isPartOf(CourseSection.builder().id(SECTION_IRI).build())
-            .build();
-
-        object = DigitalResource.builder()
-            .id(SECTION_IRI.concat("/resources/1/syllabus.pdf"))
-            .name("Course Syllabus")
-            .creator(actor)
-            .mediaType("application/pdf")
-            .isPartOf(collection)
-            .dateCreated(new DateTime(2018, 8, 2, 11, 32, 0, 0, DateTimeZone.UTC))
+        object = Document.builder()
+            .id(BASE_IRI.concat("/etexts/201.epub"))
+            .name("IMS Caliper Implementation Guide")
+            .version("1.1")
+            .dateCreated(new DateTime(2016, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
+            .datePublished(new DateTime(2016, 10, 1, 6, 0, 0, 0, DateTimeZone.UTC))
             .build();
 
         edApp = SoftwareApplication.builder().id(BASE_IRI).coercedToId(true).build();
 
         group = CourseSection.builder()
-            .id(SECTION_IRI)
+            .id(BASE_IRI.concat("/terms/201601/courses/7/sections/1"))
             .courseNumber("CPS 435-01")
-            .academicSession("Fall 2018")
+            .academicSession("Fall 2016")
             .build();
 
         membership = Membership.builder()
-            .id(BASE_IRI.concat("/terms/201801/courses/7/sections/1/rosters/1"))
+            .id(BASE_IRI.concat("/terms/201601/courses/7/sections/1/rosters/1"))
             .member(Person.builder().id(actor.getId()).coercedToId(true).build())
-            .organization(CourseSection.builder().id(SECTION_IRI).coercedToId(true).build())
+            .organization(CourseSection.builder().id(group.getId()).coercedToId(true).build())
             .status(Status.ACTIVE)
-            .role(Role.INSTRUCTOR)
-            .dateCreated(new DateTime(2018, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
+            .role(Role.LEARNER)
+            .dateCreated(new DateTime(2016, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
             .build();
 
         session = Session.builder()
             .id(BASE_IRI.concat("/sessions/1f6442a482de72ea6ad134943812bff564a76259"))
-            .startedAtTime(new DateTime(2018, 11, 15, 10, 0, 0, 0, DateTimeZone.UTC))
+            .startedAtTime(new DateTime(2016, 11, 15, 10, 0, 0, 0, DateTimeZone.UTC))
             .build();
 
         // Build event
-        event = buildEvent(Profile.RESOURCE_MANAGEMENT, Action.CREATED);
+        event = buildEvent(Profile.READING, Action.VIEWED);
     }
 
     @Test
     public void caliperEventSerializesToJSON() throws Exception {
         ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
+
         String json = mapper.writeValueAsString(event);
 
-        String fixture = jsonFixture("fixtures/v1p2/caliperEventResourceManagementCreated.json");
+        String fixture = jsonFixture("fixtures/v1p2/caliperEventViewViewedDocument.json");
         JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Test(expected=IllegalArgumentException.class)
-    public void resourceManagementEventRejectsLaunchedAction() {
-        buildEvent(Profile.SURVEY, Action.LAUNCHED);
+    public void viewEventRejectsNavigatedToAction() {
+        buildEvent(Profile.READING, Action.NAVIGATED_TO);
     }
 
     @After
@@ -132,19 +124,19 @@ public class ResourceManagementEventCreatedTest {
     }
 
     /**
-     * Build ResourceManagementEvent.
+     * Build ViewEvent.
      * @param profile, action
      * @return event
      */
-    private ResourceManagementEvent buildEvent(CaliperProfile profile, CaliperAction action) {
-        return ResourceManagementEvent.builder()
+    private ViewEvent buildEvent(CaliperProfile profile, CaliperAction action) {
+        return ViewEvent.builder()
             .context(context)
-            .profile(profile)
             .id(id)
+            .profile(profile)
             .actor(actor)
             .action(action)
             .object(object)
-            .eventTime(new DateTime(2018, 11, 15, 10, 5, 0, 0, DateTimeZone.UTC))
+            .eventTime(new DateTime(2016, 11, 15, 10, 15, 0, 0, DateTimeZone.UTC))
             .edApp(edApp)
             .group(group)
             .membership(membership)

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/ViewEventViewedQuestionnaireItemTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/ViewEventViewedQuestionnaireItemTest.java
@@ -19,6 +19,7 @@
 package org.imsglobal.caliper.v1p2.events;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
 import org.imsglobal.caliper.TestUtils;
 import org.imsglobal.caliper.actions.Action;
 import org.imsglobal.caliper.actions.CaliperAction;
@@ -45,6 +46,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import java.util.List;
 
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
@@ -77,10 +80,13 @@ public class ViewEventViewedQuestionnaireItemTest {
             .questionPosed("What would you change about your course?")
             .build();
 
+        List<String> categories = Lists.newArrayList();
+        categories.add("teaching effectiveness");
+
         object = QuestionnaireItem.builder()
             .id(ITEM_IRI)
             .question(question)
-            .category("teaching effectiveness")
+            .categories(categories)
             .category("Course structure")
             .weight(1.0)
             .build();

--- a/src/test/java/org/imsglobal/caliper/v1p2/events/ViewEventViewedQuestionnaireItemTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/events/ViewEventViewedQuestionnaireItemTest.java
@@ -31,10 +31,10 @@ import org.imsglobal.caliper.entities.agent.Person;
 import org.imsglobal.caliper.entities.agent.Role;
 import org.imsglobal.caliper.entities.agent.SoftwareApplication;
 import org.imsglobal.caliper.entities.agent.Status;
-import org.imsglobal.caliper.entities.resource.DigitalResource;
-import org.imsglobal.caliper.entities.resource.DigitalResourceCollection;
+import org.imsglobal.caliper.entities.question.OpenEndedQuestion;
+import org.imsglobal.caliper.entities.resource.QuestionnaireItem;
 import org.imsglobal.caliper.entities.session.Session;
-import org.imsglobal.caliper.events.ResourceManagementEvent;
+import org.imsglobal.caliper.events.ViewEvent;
 import org.imsglobal.caliper.profiles.CaliperProfile;
 import org.imsglobal.caliper.profiles.Profile;
 import org.joda.time.DateTime;
@@ -49,41 +49,40 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
 @Category(org.imsglobal.caliper.UnitTest.class)
-public class ResourceManagementEventCreatedTest {
+public class ViewEventViewedQuestionnaireItemTest {
     private JsonldContext context;
     private String id;
     private Person actor;
-    private CourseSection section;
-    private DigitalResource object;
-    private DigitalResourceCollection collection;
+    private QuestionnaireItem object;
+    private SoftwareApplication edApp;
     private CourseSection group;
     private Membership membership;
-    private ResourceManagementEvent event;
     private Session session;
-    private SoftwareApplication edApp;
+    private ViewEvent event;
 
     private static final String BASE_IRI = "https://example.edu";
+    private static final String ITEM_IRI = BASE_IRI.concat("/surveys/100/questionnaires/30/items/2");
     private static final String SECTION_IRI = BASE_IRI.concat("/terms/201801/courses/7/sections/1");
 
     @Before
     public void setUp() throws Exception {
         context = JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value());
-        id = "urn:uuid:0c81f804-62ee-4953-81c5-62d9579c4369";
+
+        id = "urn:uuid:bc780773-ee1e-49f6-ab2b-fe16eb391dd8";
+
         actor = Person.builder().id(BASE_IRI.concat("/users/554433")).build();
 
-        collection = DigitalResourceCollection.builder()
-            .id(SECTION_IRI.concat("/resources/1"))
-            .name("Course Assets")
-            .isPartOf(CourseSection.builder().id(SECTION_IRI).build())
+        OpenEndedQuestion question = OpenEndedQuestion.builder()
+            .id(ITEM_IRI.concat("/question"))
+            .questionPosed("What would you change about your course?")
             .build();
 
-        object = DigitalResource.builder()
-            .id(SECTION_IRI.concat("/resources/1/syllabus.pdf"))
-            .name("Course Syllabus")
-            .creator(actor)
-            .mediaType("application/pdf")
-            .isPartOf(collection)
-            .dateCreated(new DateTime(2018, 8, 2, 11, 32, 0, 0, DateTimeZone.UTC))
+        object = QuestionnaireItem.builder()
+            .id(ITEM_IRI)
+            .question(question)
+            .category("teaching effectiveness")
+            .category("Course structure")
+            .weight(1.0)
             .build();
 
         edApp = SoftwareApplication.builder().id(BASE_IRI).coercedToId(true).build();
@@ -95,35 +94,36 @@ public class ResourceManagementEventCreatedTest {
             .build();
 
         membership = Membership.builder()
-            .id(BASE_IRI.concat("/terms/201801/courses/7/sections/1/rosters/1"))
+            .id(SECTION_IRI.concat("/rosters/1"))
             .member(Person.builder().id(actor.getId()).coercedToId(true).build())
             .organization(CourseSection.builder().id(SECTION_IRI).coercedToId(true).build())
+            .role(Role.LEARNER)
             .status(Status.ACTIVE)
-            .role(Role.INSTRUCTOR)
             .dateCreated(new DateTime(2018, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
             .build();
 
         session = Session.builder()
-            .id(BASE_IRI.concat("/sessions/1f6442a482de72ea6ad134943812bff564a76259"))
-            .startedAtTime(new DateTime(2018, 11, 15, 10, 0, 0, 0, DateTimeZone.UTC))
+            .id(BASE_IRI.concat("/sessions/f095bbd391ea4a5dd639724a40b606e98a631823"))
+            .startedAtTime(new DateTime(2018, 11, 12, 10, 0, 0, 0, DateTimeZone.UTC))
             .build();
 
         // Build event
-        event = buildEvent(Profile.RESOURCE_MANAGEMENT, Action.CREATED);
+        event = buildEvent(Profile.SURVEY, Action.VIEWED);
     }
 
     @Test
     public void caliperEventSerializesToJSON() throws Exception {
         ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
+
         String json = mapper.writeValueAsString(event);
 
-        String fixture = jsonFixture("fixtures/v1p2/caliperEventResourceManagementCreated.json");
+        String fixture = jsonFixture("fixtures/v1p2/caliperEventViewViewedQuestionnaireItem.json");
         JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Test(expected=IllegalArgumentException.class)
-    public void resourceManagementEventRejectsLaunchedAction() {
-        buildEvent(Profile.SURVEY, Action.LAUNCHED);
+    public void viewEventRejectsNavigatedToAction() {
+        buildEvent(Profile.SURVEY, Action.NAVIGATED_TO);
     }
 
     @After
@@ -132,19 +132,19 @@ public class ResourceManagementEventCreatedTest {
     }
 
     /**
-     * Build ResourceManagementEvent.
+     * Build ViewEvent.
      * @param profile, action
      * @return event
      */
-    private ResourceManagementEvent buildEvent(CaliperProfile profile, CaliperAction action) {
-        return ResourceManagementEvent.builder()
+    private ViewEvent buildEvent(CaliperProfile profile, CaliperAction action) {
+        return ViewEvent.builder()
             .context(context)
-            .profile(profile)
             .id(id)
+            .profile(profile)
             .actor(actor)
             .action(action)
             .object(object)
-            .eventTime(new DateTime(2018, 11, 15, 10, 5, 0, 0, DateTimeZone.UTC))
+            .eventTime(new DateTime(2018, 11, 12, 10, 15, 0, 0, DateTimeZone.UTC))
             .edApp(edApp)
             .group(group)
             .membership(membership)


### PR DESCRIPTION
This PR aims to round out the v1p2 Event test coverage for the project, as well as make some changes to Entity and Event classes to fix bugs and enable more flexible object building. See below for additional details about my workflow.

1) First, I moved existing v1p1 Event tests to the `v1p2` test directory and updated them, primarily by changing class and fixtures names and incorporating profile properties.

2) Second, I added new tests (using preexisting tests as models) for each Event fixture in `caliper-spec/fixtures/v1p2`, with `caliperMessageEventPostedInlineContext.json` being an exception (I'll be addressing special context-related tests in future PRs).

3) I ran through all Event tests a couple times to try to achieve some consistency in the use of comments, spacing, and imports; to ensure all Event subtype tests included a `[some]EventRejects[some]ActionTest`; and to mix up the use of builder methods for list properties. To explain the last, essentially when adding multiple values (2+) to a list property in an Event test, I reworked the implementation so that both the single- and multiple-addition builder methods were used (e.g. `.categories` and `.category`). This means both builder methods are being tested more often.

4) While completing the above, I had to make small tweaks to some Entity and Event classes, usually by adding single-addition builder methods but some other cases, such as modifying the `Link` class to implement the `CaliperTargetable` interface.