### PR TITLE
Move and update preexisting Entity tests

### DIFF
--- a/src/test/java/org/imsglobal/caliper/v1p2/entities/AgentTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/entities/AgentTest.java
@@ -1,0 +1,67 @@
+/**
+ * This file is part of IMS Caliper Analytics™ and is licensed to
+ * IMS Global Learning Consortium, Inc. (http://www.imsglobal.org)
+ * under one or more contributor license agreements.  See the NOTICE
+ * file distributed with this work for additional information.
+ *
+ * IMS Caliper is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * IMS Caliper is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.imsglobal.caliper.v1p2.entities;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.imsglobal.caliper.TestUtils;
+import org.imsglobal.caliper.context.CaliperJsonldContextIRI;
+import org.imsglobal.caliper.context.JsonldStringContext;
+import org.imsglobal.caliper.entities.agent.Agent;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
+
+@Category(org.imsglobal.caliper.UnitTest.class)
+public class AgentTest {
+    private Agent entity;
+
+    private static final String BASE_IRI = "https://example.edu";
+
+    @Before
+    public void setUp() throws Exception {
+
+        entity = Agent.builder()
+            .context(JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value()))
+            .id(BASE_IRI.concat("/agents/99999"))
+            .dateCreated(new DateTime(2016, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
+            .dateModified(new DateTime(2016, 9, 2, 11, 30, 0, 0, DateTimeZone.UTC))
+            .build();
+    }
+
+    @Test
+    public void caliperEntitySerializesToJSON() throws Exception {
+        ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
+        String json = mapper.writeValueAsString(entity);
+
+        String fixture = jsonFixture("fixtures/v1p2/caliperEntityAgent.json");
+        JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
+    }
+
+    @After
+    public void teardown() {
+        entity = null;
+    }
+}

--- a/src/test/java/org/imsglobal/caliper/v1p2/entities/AggregateMeasureCollectionTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/entities/AggregateMeasureCollectionTest.java
@@ -45,9 +45,6 @@ public class AggregateMeasureCollectionTest {
     private AggregateMeasure unitsCompleted;
     private AggregateMeasure minutesOnTask;
 
-    private static final String BASE_IRI = "https://example.edu";
-    private static final String SECTION_IRI = BASE_IRI.concat("/terms/201601/courses/7/sections/1");
-
     @Before
     public void setUp() throws Exception {
 
@@ -79,7 +76,6 @@ public class AggregateMeasureCollectionTest {
             .id("urn:uuid:60b4db01-f1e5-4a7f-add9-6a8f761625b1")
             .items(measures)
             .build();
-
     }
 
     @Test

--- a/src/test/java/org/imsglobal/caliper/v1p2/entities/AssessmentItemExtendedTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/entities/AssessmentItemExtendedTest.java
@@ -1,0 +1,143 @@
+/**
+ * This file is part of IMS Caliper Analytics™ and is licensed to
+ * IMS Global Learning Consortium, Inc. (http://www.imsglobal.org)
+ * under one or more contributor license agreements.  See the NOTICE
+ * file distributed with this work for additional information.
+ *
+ * IMS Caliper is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * IMS Caliper is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.imsglobal.caliper.v1p2.entities;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Maps;
+import org.imsglobal.caliper.TestUtils;
+import org.imsglobal.caliper.context.CaliperJsonldContextIRI;
+import org.imsglobal.caliper.context.JsonldStringContext;
+import org.imsglobal.caliper.entities.resource.Assessment;
+import org.imsglobal.caliper.entities.resource.AssessmentItem;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import java.util.Map;
+
+import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
+
+@Category(org.imsglobal.caliper.UnitTest.class)
+public class AssessmentItemExtendedTest {
+    private AssessmentItem entity;
+
+    private static final String BASE_IRI = "https://example.edu";
+    private static final String SECTION_IRI = BASE_IRI.concat("/terms/201601/courses/7/sections/1");
+
+    @Before
+    public void setUp() throws Exception {
+
+        // Parent
+        Assessment assessment = Assessment.builder()
+            .id("https://example.edu/terms/201601/courses/7/sections/1/assess/1")
+            .build();
+
+        // Add AssessmentItem Extensions
+        Question question = Question.create();
+        Map<String, Object> extensions = Maps.newHashMap();
+        extensions.put("questionType", question.getQuestionType());
+        extensions.put("questionText", question.getQuestionText());
+        extensions.put("correctResponse", question.getCorrectResponse());
+
+        entity = AssessmentItem.builder()
+            .context(JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value()))
+            .id(SECTION_IRI.concat("/assess/1/items/3"))
+            .isPartOf(assessment)
+            .dateCreated(new DateTime(2016, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
+            .datePublished(new DateTime(2016, 8, 15, 9, 30, 0, 0, DateTimeZone.UTC))
+            .maxScore(1.0)
+            .maxSubmits(2)
+            .isTimeDependent(false)
+            .extensions(extensions)
+            .build();
+    }
+
+    @Test
+    public void caliperEntitySerializesToJSON() throws Exception {
+        ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
+        String json = mapper.writeValueAsString(entity);
+
+        String fixture = jsonFixture("fixtures/v1p2/caliperEntityAssessmentItemExtended.json");
+        JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
+    }
+
+    @After
+    public void teardown() {
+        entity = null;
+    }
+
+    /**
+     * Question extension
+     */
+    static class Question {
+        private String questionType;
+        private String questionText;
+        private String correctResponse;
+
+        /**
+         * Constructor
+         */
+        private Question() {
+            this.questionType = "Dichotomous";
+            this.questionText = "Is a Caliper SoftwareApplication a subtype of Caliper Agent?";
+            this.correctResponse = "yes";
+        }
+
+        /**
+         * Get the question type.
+         * @return the questionType
+         */
+        @JsonProperty("questionType")
+        private String getQuestionType() {
+            return questionType;
+        }
+
+        /**
+         * Get the question text.
+         * @return the questionText
+         */
+        @JsonProperty("questionText")
+        private String getQuestionText() {
+            return questionText;
+        }
+
+        /**
+         * Get the correct response.
+         * @return the correctResponse
+         */
+        @JsonProperty("correctResponse")
+        private String getCorrectResponse() {
+            return correctResponse;
+        }
+
+        /**
+         * Factory method
+         * @return new Question
+         */
+        private static Question create() {
+            return new Question();
+        }
+    }
+}

--- a/src/test/java/org/imsglobal/caliper/v1p2/entities/AssessmentTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/entities/AssessmentTest.java
@@ -1,0 +1,88 @@
+/**
+ * This file is part of IMS Caliper Analytics™ and is licensed to
+ * IMS Global Learning Consortium, Inc. (http://www.imsglobal.org)
+ * under one or more contributor license agreements.  See the NOTICE
+ * file distributed with this work for additional information.
+ *
+ * IMS Caliper is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * IMS Caliper is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.imsglobal.caliper.v1p2.entities;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
+import org.imsglobal.caliper.TestUtils;
+import org.imsglobal.caliper.context.CaliperJsonldContextIRI;
+import org.imsglobal.caliper.context.JsonldStringContext;
+import org.imsglobal.caliper.entities.resource.Assessment;
+import org.imsglobal.caliper.entities.resource.AssessmentItem;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import java.util.List;
+
+import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
+
+@Category(org.imsglobal.caliper.UnitTest.class)
+public class AssessmentTest {
+    private Assessment entity;
+
+    private static final String BASE_IRI = "https://example.edu";
+    private static final String SECTION_IRI = BASE_IRI.concat("/terms/201601/courses/7/sections/1");
+
+    @Before
+    public void setUp() throws Exception {
+
+        List<AssessmentItem> items = Lists.newArrayList();
+        items.add(AssessmentItem.builder().id(SECTION_IRI.concat("/assess/1/items/1")).build());
+        items.add(AssessmentItem.builder().id(SECTION_IRI.concat("/assess/1/items/2")).build());
+
+        entity = Assessment.builder()
+            .context(JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value()))
+            .id(SECTION_IRI.concat("/assess/1"))
+            .name("Quiz One")
+            .items(items)
+            .item(AssessmentItem.builder().id(SECTION_IRI.concat("/assess/1/items/3")).build())
+            .dateCreated(new DateTime(2016, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
+            .dateModified(new DateTime(2016, 9, 2, 11, 30, 0, 0, DateTimeZone.UTC))
+            .datePublished(new DateTime(2016, 8, 15, 9, 30, 0, 0, DateTimeZone.UTC))
+            .dateToActivate(new DateTime(2016, 8, 16, 5, 0, 0, 0, DateTimeZone.UTC))
+            .dateToShow(new DateTime(2016, 8, 16, 5, 0, 0, 0, DateTimeZone.UTC))
+            .dateToStartOn(new DateTime(2016, 8, 16, 5, 0, 0, 0, DateTimeZone.UTC))
+            .dateToSubmit(new DateTime(2016, 9, 28, 11, 59, 59, 0, DateTimeZone.UTC))
+            .maxAttempts(2)
+            .maxSubmits(2)
+            .maxScore(15.0)
+            .version("1.0")
+            .build();
+    }
+
+    @Test
+    public void caliperEntitySerializesToJSON() throws Exception {
+        ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
+        String json = mapper.writeValueAsString(entity);
+
+        String fixture = jsonFixture("fixtures/v1p2/caliperEntityAssessment.json");
+        JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
+    }
+
+    @After
+    public void teardown() {
+        entity = null;
+    }
+}

--- a/src/test/java/org/imsglobal/caliper/v1p2/entities/CollectionTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/entities/CollectionTest.java
@@ -74,12 +74,12 @@ public class CollectionTest {
 
         items = Lists.newArrayList();
         items.add(video1);
-        items.add(video2);
 
         entity = Collection.builder()
             .context(JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value()))
             .id(SECTION_IRI.concat("/resources/2"))
             .items(items)
+            .item(video2)
             .dateCreated(new DateTime(2019, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
             .dateModified(new DateTime(2019, 9, 2, 11, 30, 0, 0, DateTimeZone.UTC))
             .build();

--- a/src/test/java/org/imsglobal/caliper/v1p2/entities/CourseOfferingAnonymousTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/entities/CourseOfferingAnonymousTest.java
@@ -37,8 +37,6 @@ import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 public class CourseOfferingAnonymousTest {
     private CourseOffering entity;
 
-    private static final String BASE_IRI = "https://example.edu";
-
     @Before
     public void setUp() throws Exception {
 

--- a/src/test/java/org/imsglobal/caliper/v1p2/entities/CourseOfferingTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/entities/CourseOfferingTest.java
@@ -19,7 +19,6 @@
 package org.imsglobal.caliper.v1p2.entities;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.Lists;
 import org.imsglobal.caliper.TestUtils;
 import org.imsglobal.caliper.context.CaliperJsonldContextIRI;
 import org.imsglobal.caliper.context.JsonldStringContext;
@@ -34,8 +33,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
-
-import java.util.List;
 
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 

--- a/src/test/java/org/imsglobal/caliper/v1p2/entities/CourseSectionTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/entities/CourseSectionTest.java
@@ -1,0 +1,86 @@
+/**
+ * This file is part of IMS Caliper Analytics™ and is licensed to
+ * IMS Global Learning Consortium, Inc. (http://www.imsglobal.org)
+ * under one or more contributor license agreements.  See the NOTICE
+ * file distributed with this work for additional information.
+ *
+ * IMS Caliper is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * IMS Caliper is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.imsglobal.caliper.v1p2.entities;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.imsglobal.caliper.TestUtils;
+import org.imsglobal.caliper.context.CaliperJsonldContextIRI;
+import org.imsglobal.caliper.context.JsonldStringContext;
+import org.imsglobal.caliper.entities.agent.CourseOffering;
+import org.imsglobal.caliper.entities.agent.CourseSection;
+import org.imsglobal.caliper.identifiers.SystemIdentifier;
+import org.imsglobal.caliper.identifiers.SystemIdentifierType;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
+
+@Category(org.imsglobal.caliper.UnitTest.class)
+public class CourseSectionTest {
+    private CourseSection entity;
+    private CourseOffering courseOffering;
+
+    private static final String BASE_IRI = "https://example.edu";
+
+    @Before
+    public void setUp() throws Exception {
+
+        SystemIdentifier otherIdentifier = SystemIdentifier.builder()
+            .identifier("example.edu:SI182-001-F16")
+            .identifierType(SystemIdentifierType.LIS_SOURCED_ID)
+            .build();
+
+        courseOffering = CourseOffering.builder()
+            .id(BASE_IRI.concat("/terms/201601/courses/7"))
+            .courseNumber("CPS 435")
+            .build();
+
+        entity = CourseSection.builder()
+            .context(JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value()))
+            .id(BASE_IRI.concat("/terms/201601/courses/7/sections/1"))
+            .academicSession("Fall 2016")
+            .courseNumber("CPS 435-01")
+            .name("CPS 435 Learning Analytics, Section 01")
+            .otherIdentifier(otherIdentifier)
+            .category("seminar")
+            .subOrganizationOf(courseOffering)
+            .dateCreated(new DateTime(2016, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
+            .build();
+    }
+
+    @Test
+    public void caliperEntitySerializesToJSON() throws Exception {
+        ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
+        String json = mapper.writeValueAsString(entity);
+
+        String fixture = jsonFixture("fixtures/v1p2/caliperEntityCourseSection.json");
+        JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
+    }
+
+    @After
+    public void teardown() {
+        entity = null;
+    }
+}

--- a/src/test/java/org/imsglobal/caliper/v1p2/entities/DigitalResourceCollectionTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/entities/DigitalResourceCollectionTest.java
@@ -23,10 +23,8 @@ import com.google.common.collect.Lists;
 import org.imsglobal.caliper.TestUtils;
 import org.imsglobal.caliper.context.CaliperJsonldContextIRI;
 import org.imsglobal.caliper.context.JsonldStringContext;
-import org.imsglobal.caliper.entities.agent.CaliperAgent;
 import org.imsglobal.caliper.entities.agent.CourseOffering;
 import org.imsglobal.caliper.entities.agent.CourseSection;
-import org.imsglobal.caliper.entities.agent.Person;
 import org.imsglobal.caliper.entities.resource.CaliperDigitalResource;
 import org.imsglobal.caliper.entities.resource.DigitalResourceCollection;
 import org.imsglobal.caliper.entities.resource.VideoObject;
@@ -45,16 +43,13 @@ import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
 @Category(org.imsglobal.caliper.UnitTest.class)
 public class DigitalResourceCollectionTest {
-    private DigitalResourceCollection collection;
     private CourseOffering course;
     private CourseSection section;
-    private Person actor;
-    private List<CaliperAgent> creators;
     private List<CaliperDigitalResource> resources;
     private List<String> keywords;
-    private DigitalResourceCollection entity;
     private VideoObject video1;
     private VideoObject video2;
+    private DigitalResourceCollection entity;
 
     private static final String BASE_IRI = "https://example.edu";
     private static final String COURSE_IRI = BASE_IRI.concat("/terms/201601/courses/7");
@@ -97,7 +92,6 @@ public class DigitalResourceCollectionTest {
             .build();
 
         resources = Lists.newArrayList();
-        resources.add(video1);
         resources.add(video2);
 
         entity = DigitalResourceCollection.builder()
@@ -106,6 +100,7 @@ public class DigitalResourceCollectionTest {
             .name("Video Collection")
             .keywords(keywords)
             .items(resources)
+            .item(video1)
             .isPartOf(section)
             .dateCreated(new DateTime(2016, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
             .dateModified(new DateTime(2016, 9, 2, 11, 30, 0, 0, DateTimeZone.UTC))

--- a/src/test/java/org/imsglobal/caliper/v1p2/entities/DigitalResourceTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/entities/DigitalResourceTest.java
@@ -19,11 +19,9 @@
 package org.imsglobal.caliper.v1p2.entities;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.Lists;
 import org.imsglobal.caliper.TestUtils;
 import org.imsglobal.caliper.context.CaliperJsonldContextIRI;
 import org.imsglobal.caliper.context.JsonldStringContext;
-import org.imsglobal.caliper.entities.agent.CaliperAgent;
 import org.imsglobal.caliper.entities.agent.CourseSection;
 import org.imsglobal.caliper.entities.agent.Person;
 import org.imsglobal.caliper.entities.resource.DigitalResource;
@@ -37,8 +35,6 @@ import org.junit.experimental.categories.Category;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 
-import java.util.List;
-
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
 @Category(org.imsglobal.caliper.UnitTest.class)
@@ -46,7 +42,6 @@ public class DigitalResourceTest {
     private DigitalResourceCollection collection;
     private CourseSection section;
     private Person actor;
-    private List<CaliperAgent> creators;
     private DigitalResource entity;
 
     private static final String BASE_IRI = "https://example.edu";
@@ -58,9 +53,6 @@ public class DigitalResourceTest {
         actor = Person.builder()
             .id(BASE_IRI.concat("/users/223344"))
             .build();
-
-        creators = Lists.newArrayList();
-        creators.add(actor);
 
         section = CourseSection.builder()
             .id(SECTION_IRI)
@@ -78,7 +70,7 @@ public class DigitalResourceTest {
             .name("Course Syllabus")
             .storageName("fall-2016-syllabus.pdf")
             .mediaType("application/pdf")
-            .creators(creators)
+            .creator(actor)
             .isPartOf(collection)
             .dateCreated(new DateTime(2016, 8, 2, 11, 32, 0, 0, DateTimeZone.UTC))
             .build();

--- a/src/test/java/org/imsglobal/caliper/v1p2/entities/GroupTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/entities/GroupTest.java
@@ -1,0 +1,99 @@
+/**
+ * This file is part of IMS Caliper Analytics™ and is licensed to
+ * IMS Global Learning Consortium, Inc. (http://www.imsglobal.org)
+ * under one or more contributor license agreements.  See the NOTICE
+ * file distributed with this work for additional information.
+ *
+ * IMS Caliper is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * IMS Caliper is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.imsglobal.caliper.v1p2.entities;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
+import org.imsglobal.caliper.TestUtils;
+import org.imsglobal.caliper.context.CaliperJsonldContextIRI;
+import org.imsglobal.caliper.context.JsonldStringContext;
+import org.imsglobal.caliper.entities.agent.*;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import java.util.List;
+
+import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
+
+@Category(org.imsglobal.caliper.UnitTest.class)
+public class GroupTest {
+    private Group entity;
+    private List<CaliperAgent> people;
+    private CourseOffering courseOffering;
+    private CourseSection courseSection;
+
+    private static final String BASE_IRI = "https://example.edu";
+
+    @Before
+    public void setUp() throws Exception {
+
+        String[] iriEndings = {
+            "/users/554433",
+            "/users/778899",
+            "/users/445566",
+            "/users/667788",
+        };
+
+        Person person;
+        people = Lists.newArrayList();
+        for (String iriEnding: iriEndings) {
+            person = Person.builder().id(BASE_IRI.concat(iriEnding)).build();
+            people.add(person);
+        }
+
+        courseOffering = CourseOffering.builder()
+            .id(BASE_IRI.concat("/terms/201601/courses/7"))
+            .build();
+
+        courseSection = CourseSection.builder()
+            .id(BASE_IRI.concat("/terms/201601/courses/7/sections/1"))
+            .subOrganizationOf(courseOffering)
+            .build();
+
+        entity = Group.builder()
+            .context(JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value()))
+            .id(BASE_IRI.concat("/terms/201601/courses/7/sections/1/groups/2"))
+            .name("Discussion Group 2")
+            .subOrganizationOf(courseSection)
+            .members(people)
+            .member(Person.builder().id(BASE_IRI.concat("/users/889900")).build())
+            .dateCreated(new DateTime(2016, 11, 1, 6, 0, 0, 0, DateTimeZone.UTC))
+            .build();
+    }
+
+    @Test
+    public void caliperEntitySerializesToJSON() throws Exception {
+        ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
+        String json = mapper.writeValueAsString(entity);
+
+        String fixture = jsonFixture("fixtures/v1p2/caliperEntityGroup.json");
+        JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
+    }
+
+    @After
+    public void teardown() {
+        entity = null;
+    }
+}

--- a/src/test/java/org/imsglobal/caliper/v1p2/entities/LtiLinkTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/entities/LtiLinkTest.java
@@ -24,8 +24,6 @@ import org.imsglobal.caliper.context.CaliperJsonldContextIRI;
 import org.imsglobal.caliper.context.JsonldStringContext;
 import org.imsglobal.caliper.entities.resource.LtiLink;
 import org.imsglobal.caliper.entities.resource.LtiMessageType;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/org/imsglobal/caliper/v1p2/entities/MembershipTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/entities/MembershipTest.java
@@ -1,0 +1,84 @@
+/**
+ * This file is part of IMS Caliper Analytics™ and is licensed to
+ * IMS Global Learning Consortium, Inc. (http://www.imsglobal.org)
+ * under one or more contributor license agreements.  See the NOTICE
+ * file distributed with this work for additional information.
+ *
+ * IMS Caliper is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * IMS Caliper is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.imsglobal.caliper.v1p2.entities;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.imsglobal.caliper.TestUtils;
+import org.imsglobal.caliper.context.CaliperJsonldContextIRI;
+import org.imsglobal.caliper.context.JsonldStringContext;
+import org.imsglobal.caliper.entities.agent.*;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
+
+@Category(org.imsglobal.caliper.UnitTest.class)
+public class MembershipTest {
+    private Membership entity;
+    private Person person;
+    private CourseOffering courseOffering;
+    private CourseSection courseSection;
+
+    private static final String BASE_IRI = "https://example.edu";
+
+    @Before
+    public void setUp() throws Exception {
+
+        person = Person.builder().id(BASE_IRI.concat("/users/554433")).build();
+
+        courseOffering = CourseOffering.builder()
+            .id(BASE_IRI.concat("/terms/201601/courses/7"))
+            .build();
+
+        courseSection = CourseSection.builder()
+            .id(BASE_IRI.concat("/terms/201601/courses/7/sections/1"))
+            .subOrganizationOf(courseOffering)
+            .build();
+
+        entity = Membership.builder()
+            .context(JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value()))
+            .id(BASE_IRI.concat("/terms/201601/courses/7/sections/1/rosters/1/members/554433"))
+            .member(person)
+            .organization(courseSection)
+            .role(Role.LEARNER)
+            .status(Status.ACTIVE)
+            .dateCreated(new DateTime(2016, 11, 1, 6, 0, 0, 0, DateTimeZone.UTC))
+            .build();
+    }
+
+    @Test
+    public void caliperEntitySerializesToJSON() throws Exception {
+        ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
+        String json = mapper.writeValueAsString(entity);
+
+        String fixture = jsonFixture("fixtures/v1p2/caliperEntityMembership.json");
+        JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
+    }
+
+    @After
+    public void teardown() {
+        entity = null;
+    }
+}

--- a/src/test/java/org/imsglobal/caliper/v1p2/entities/MultipleResponseResponseTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/entities/MultipleResponseResponseTest.java
@@ -70,7 +70,7 @@ public class MultipleResponseResponseTest {
             .endedAtTime(new DateTime(2016, 11, 15, 10, 15, 30, 0, DateTimeZone.UTC))
             .build();
 
-        String[] valueArray = {"A", "D", "E"};
+        String[] valueArray = {"A", "D"};
         List<String> values = Lists.newArrayList();
         values.addAll(Arrays.asList(valueArray));
 
@@ -82,6 +82,7 @@ public class MultipleResponseResponseTest {
             .startedAtTime(new DateTime(2016, 11, 15, 10, 15, 22, 0, DateTimeZone.UTC))
             .endedAtTime(new DateTime(2016, 11, 15, 10, 15, 30, 0, DateTimeZone.UTC))
             .values(values)
+            .value("E")
             .build();
     }
 

--- a/src/test/java/org/imsglobal/caliper/v1p2/entities/MultiselectQuestionTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/entities/MultiselectQuestionTest.java
@@ -41,23 +41,22 @@ public class MultiselectQuestionTest {
     private MultiselectQuestion entity;
 
     private static final String BASE_IRI = "https://example.edu";
+    private static final String SECTION_IRI = BASE_IRI.concat("/terms/201801/courses/7/sections/1");
 
     @Before
     public void setUp() throws Exception {
 
-        String[] labelArray = {"Calculus", "Number theory", "Combinatorics", "Algebra"};
+        String[] labelArray = {"Calculus", "Number theory", "Combinatorics"};
         List<String> itemLabels = Lists.newArrayList();
         itemLabels.addAll(Arrays.asList(labelArray));
 
         String[] valueArray = {
-            "https://example.edu/terms/201801/courses/7/sections/1/objectives/1",
-            "https://example.edu/terms/201801/courses/7/sections/1/objectives/2",
-            "https://example.edu/terms/201801/courses/7/sections/1/objectives/3",
-            "https://example.edu/terms/201801/courses/7/sections/1/objectives/4"
+            SECTION_IRI.concat("/objectives/1"),
+            SECTION_IRI.concat("/objectives/2"),
+            SECTION_IRI.concat("/objectives/3")
         };
         List<String> itemValues = Lists.newArrayList();
         itemValues.addAll(Arrays.asList(valueArray));
-
 
         entity = MultiselectQuestion.builder()
             .context(JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value()))
@@ -65,7 +64,9 @@ public class MultiselectQuestionTest {
             .questionPosed("What do you want to study today?")
             .points(4)
             .itemLabels(itemLabels)
+            .itemLabel("Algebra")
             .itemValues(itemValues)
+            .itemValue(SECTION_IRI.concat("/objectives/4"))
             .build();
     }
 

--- a/src/test/java/org/imsglobal/caliper/v1p2/entities/MultiselectResponseTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/entities/MultiselectResponseTest.java
@@ -34,7 +34,6 @@ import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 
 import java.util.List;
-import java.util.Arrays;
 
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
@@ -43,20 +42,18 @@ public class MultiselectResponseTest {
     private MultiselectResponse entity;
 
     private static final String BASE_IRI = "https://example.edu";
+    private static final String SECTION_IRI = BASE_IRI.concat("/terms/201801/courses/7/sections/1");
 
     @Before
     public void setUp() throws Exception {
-        String[] selectionArray = {
-            "https://example.edu/terms/201801/courses/7/sections/1/objectives/1",
-            "https://example.edu/terms/201801/courses/7/sections/1/objectives/2",
-        };
         List<String> selections = Lists.newArrayList();
-        selections.addAll(Arrays.asList(selectionArray));
+        selections.add(SECTION_IRI.concat("/objectives/1"));
 
         entity = MultiselectResponse.builder()
             .context(JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value()))
             .id(BASE_IRI.concat("/surveys/100/questionnaires/30/items/5/users/554433/responses/5"))
             .selections(selections)
+            .selection(SECTION_IRI.concat("/objectives/2"))
             .startedAtTime(new DateTime(2018, 8, 1, 5, 55, 48, 0, DateTimeZone.UTC))
             .endedAtTime(new DateTime(2018, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
             .duration("PT4M12S")

--- a/src/test/java/org/imsglobal/caliper/v1p2/entities/OrganizationTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/entities/OrganizationTest.java
@@ -1,0 +1,71 @@
+/**
+ * This file is part of IMS Caliper Analytics™ and is licensed to
+ * IMS Global Learning Consortium, Inc. (http://www.imsglobal.org)
+ * under one or more contributor license agreements.  See the NOTICE
+ * file distributed with this work for additional information.
+ *
+ * IMS Caliper is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * IMS Caliper is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.imsglobal.caliper.v1p2.entities;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.imsglobal.caliper.TestUtils;
+import org.imsglobal.caliper.context.CaliperJsonldContextIRI;
+import org.imsglobal.caliper.context.JsonldStringContext;
+import org.imsglobal.caliper.entities.agent.Organization;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
+
+@Category(org.imsglobal.caliper.UnitTest.class)
+public class OrganizationTest {
+    private Organization entity;
+    private Organization college;
+
+    private static final String BASE_IRI = "https://example.edu";
+
+    @Before
+    public void setUp() throws Exception {
+
+        college = Organization.builder()
+            .id(BASE_IRI.concat("/colleges/1"))
+            .name("College of Engineering")
+            .build();
+
+        entity = Organization.builder()
+            .context(JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value()))
+            .id(BASE_IRI.concat("/colleges/1/depts/1"))
+            .name("Computer Science Department")
+            .subOrganizationOf(college)
+            .build();
+    }
+
+    @Test
+    public void caliperEntitySerializesToJSON() throws Exception {
+        ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
+        String json = mapper.writeValueAsString(entity);
+
+        String fixture = jsonFixture("fixtures/v1p2/caliperEntityOrganization.json");
+        JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
+    }
+
+    @After
+    public void teardown() {
+        entity = null;
+    }
+}

--- a/src/test/java/org/imsglobal/caliper/v1p2/entities/PersonTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/entities/PersonTest.java
@@ -79,7 +79,7 @@ public class PersonTest {
             .extensions(extensionsForFour)
             .build();
 
-        SystemIdentifier[] systemIdentifierArray = { identifierOne,  identifierTwo, identifierThree, identifierFour };
+        SystemIdentifier[] systemIdentifierArray = { identifierOne,  identifierTwo, identifierThree };
 
         List<SystemIdentifier> otherIdentifiers = Lists.newArrayList();
         otherIdentifiers.addAll(Arrays.asList(systemIdentifierArray));
@@ -88,6 +88,7 @@ public class PersonTest {
             .context(JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value()))
             .id(BASE_IRI.concat("/users/554433"))
             .otherIdentifiers(otherIdentifiers)
+            .otherIdentifier(identifierFour)
             .dateCreated(new DateTime(2016, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
             .dateModified(new DateTime(2016, 9, 2, 11, 30, 0, 0, DateTimeZone.UTC))
             .build();

--- a/src/test/java/org/imsglobal/caliper/v1p2/entities/RatingScaleQuestionTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/entities/RatingScaleQuestionTest.java
@@ -54,19 +54,19 @@ public class RatingScaleQuestionTest {
         labels.add("Strongly Disagree");
         labels.add("Disagree");
         labels.add("Agree");
-        labels.add("Strongly Agree");
 
         values = Lists.newArrayList();
         values.add("-2");
         values.add("-1");
         values.add("1");
-        values.add("2");
 
         scale = LikertScale.builder()
             .id(BASE_IRI.concat("/scale/2"))
             .scalePoints(4)
             .itemLabels(labels)
+            .itemLabel("Strongly Agree")
             .itemValues(values)
+            .itemValue("2")
             .dateCreated(new DateTime(2018, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
             .build();
 

--- a/src/test/java/org/imsglobal/caliper/v1p2/entities/RatingScaleResponseTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/entities/RatingScaleResponseTest.java
@@ -19,8 +19,6 @@
 package org.imsglobal.caliper.v1p2.entities;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 import org.imsglobal.caliper.TestUtils;
 import org.imsglobal.caliper.context.CaliperJsonldContextIRI;
 import org.imsglobal.caliper.context.JsonldStringContext;
@@ -34,27 +32,21 @@ import org.junit.experimental.categories.Category;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 
-import java.util.List;
-
 import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
 
 @Category(org.imsglobal.caliper.UnitTest.class)
 public class RatingScaleResponseTest {
     private RatingScaleResponse entity;
-    private List<String> selections;
 
     private static final String BASE_IRI = "https://example.edu";
 
     @Before
     public void setUp() throws Exception {
 
-        selections = Lists.newArrayList();
-        selections.add("Satisfied");
-
         entity = RatingScaleResponse.builder()
             .context(JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value()))
             .id(BASE_IRI.concat("/surveys/100/questionnaires/30/items/1/users/554433/responses/1"))
-            .selections(selections)
+            .selection("Satisfied")
             .startedAtTime(new DateTime(2018, 8, 1, 5, 55, 48, 0, DateTimeZone.UTC))
             .endedAtTime(new DateTime(2018, 8, 1, 6, 0, 0, 0, DateTimeZone.UTC))
             .duration("PT4M12S")

--- a/src/test/java/org/imsglobal/caliper/v1p2/entities/SearchResponseTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/entities/SearchResponseTest.java
@@ -47,7 +47,7 @@ public class SearchResponseTest {
     private SearchResponse entity;
 
     private static final String BASE_IRI = "https://example.edu";
-    private static final String BASE_CATALOG_IRI = "https://example.edu/catalog";
+    private static final String BASE_CATALOG_IRI = BASE_IRI.concat("/catalog");
 
     @Before
     public void setUp() throws Exception {

--- a/src/test/java/org/imsglobal/caliper/v1p2/entities/SoftwareApplicationTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p2/entities/SoftwareApplicationTest.java
@@ -1,0 +1,66 @@
+/**
+ * This file is part of IMS Caliper Analytics™ and is licensed to
+ * IMS Global Learning Consortium, Inc. (http://www.imsglobal.org)
+ * under one or more contributor license agreements.  See the NOTICE
+ * file distributed with this work for additional information.
+ *
+ * IMS Caliper is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * IMS Caliper is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.imsglobal.caliper.v1p2.entities;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.imsglobal.caliper.TestUtils;
+import org.imsglobal.caliper.context.CaliperJsonldContextIRI;
+import org.imsglobal.caliper.context.JsonldStringContext;
+import org.imsglobal.caliper.entities.agent.SoftwareApplication;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import static com.yammer.dropwizard.testing.JsonHelpers.jsonFixture;
+
+@Category(org.imsglobal.caliper.UnitTest.class)
+public class SoftwareApplicationTest {
+    private SoftwareApplication entity;
+
+    private static final String BASE_IRI = "https://example.edu";
+
+    @Before
+    public void setUp() throws Exception {
+
+        entity = SoftwareApplication.builder()
+            .context(JsonldStringContext.create(CaliperJsonldContextIRI.V1P2.value()))
+            .id(BASE_IRI.concat("/autograder"))
+            .name("Auto Grader")
+            .description("Automates assignment scoring.")
+            .version("2.5.2")
+            .build();
+    }
+
+    @Test
+    public void caliperEntitySerializesToJSON() throws Exception {
+        ObjectMapper mapper = TestUtils.createCaliperObjectMapper();
+        String json = mapper.writeValueAsString(entity);
+
+        String fixture = jsonFixture("fixtures/v1p2/caliperEntitySoftwareApplication.json");
+        JSONAssert.assertEquals(fixture, json, JSONCompareMode.NON_EXTENSIBLE);
+    }
+
+    @After
+    public void teardown() {
+        entity = null;
+    }
+}


### PR DESCRIPTION
This PR moves preexisting v1p1 Entity tests to `test/v1p2/entities` and updates them accordingly, as well as modifies existing v1p2 tests to increase consistency in the use of formatting, imports, and list-builder methods across the whole test package. See below for additional details.

1) I moved existing v1p1 Entity tests to the v1p2 test directory and updated them, primarily by changing the context value and the path to the fixture. Occasionally, new properties had to be added (e.g. `otherIdentifiers` in `CourseSectionTest`).

2) I scanned and updated all Entity tests to try to achieve some consistency in the use of comments, spacing, and imports, and to mix up the use of builder methods for list properties. To explain the latter, essentially when adding multiple values (2+) to a list property in an Entity test, I reworked the implementation so that both the single- and multiple-addition builder methods were used (e.g. `.categories` and `.category`). This increases the spread of methods being tested.