### PR TITLE
Update pom.xml to include latest dependency versions and JaCoCo plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
 
     <properties>
         <caliper.jdk.version>1.8</caliper.jdk.version>
-        <jackson.version>2.9.9</jackson.version>
+        <jackson.version>2.10.1</jackson.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <sonatypeOssDistMgmtSnapshotsUrl>https://oss.sonatype.org/content/repositories/snapshots/</sonatypeOssDistMgmtSnapshotsUrl>
         <arguments />
@@ -113,17 +113,17 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.8.0-beta4</version>
+            <version>2.0.0-alpha1</version>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
-            <version>2.10.2</version>
+            <version>2.10.5</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.8</version>
+            <version>4.5.10</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -154,12 +154,12 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>27.1-jre</version>
+            <version>28.1-jre</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13-beta-3</version>
+            <version>4.13-rc-1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -171,7 +171,7 @@
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
-            <version>2.0.2</version>
+            <version>2.0.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -236,6 +236,25 @@
                                 </requireJavaVersion>
                             </rules>
                         </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.5</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
This PR provides updates to `pom.xml` to update the project's dependencies and add the JaCoCo plugin to assist with assessing the coverage of unit tests. More details on both changes are provided below.

1) I accomplished the former by running Maven commands, including `mvn versions:display-dependency-updates` and `mvn versions:use-latest-releases`, which made automatic changes to `pom.xml`. I also manually updated the `jackson.version` specified in `<properties>`, as that particular dependency wasn't updated by the Maven commands. Changes were saved using `mvn versions:commit`, which deleted the auto-generated `pom.xml` backup. I referenced [this Baeldung article](https://www.baeldung.com/maven-dependency-latest-version) while performing these actions.

2) To help us assess how well the unit tests cover the Entity and Event classes and the project as a whole, I decided to add the [JaCoCo plugin](https://mvnrepository.com/artifact/org.jacoco/jacoco-maven-plugin) under `<build><plugins>`. I referenced this [Mkyong.com article](https://www.mkyong.com/maven/maven-jacoco-code-coverage-example/), which provided a sample `<plugin>` element that I used. 