### PR TITLE
Correcting the DATA_VERSION to match the 1.2 specification v1p2 

### DIFF
--- a/src/main/java/org/imsglobal/caliper/config/Config.java
+++ b/src/main/java/org/imsglobal/caliper/config/Config.java
@@ -36,7 +36,7 @@ public class Config {
     /**
      * Default version
      */
-    public static final String DATA_VERSION = "http://purl.imsglobal.org/ctx/caliper/v1p1";
+    public static final String DATA_VERSION = "http://purl.imsglobal.org/ctx/caliper/v1p2";
 
     /**
      * Default UUID version to use when minting Event UUIDs.

--- a/src/test/java/org/imsglobal/caliper/v1p1/envelopes/EnvelopeEventSingleTest.java
+++ b/src/test/java/org/imsglobal/caliper/v1p1/envelopes/EnvelopeEventSingleTest.java
@@ -145,7 +145,7 @@ public class EnvelopeEventSingleTest {
         sensor.registerClient(client);
 
         // Create envelope
-        envelope = sensor.create(sensor.getId(), sendTime, Config.DATA_VERSION, data);
+        envelope = sensor.create(sensor.getId(), sendTime, CaliperJsonldContextIRI.V1P1.value(), data);
 
         // Don't send
         // sensor.send(client, envelope);


### PR DESCRIPTION
Correcting the DATA_VERSION to match the 1.2 specification v1p2 string that is expected by the IMS certification suite